### PR TITLE
Revamp chat experience

### DIFF
--- a/apps/web/app/components/ConversationHistory.tsx
+++ b/apps/web/app/components/ConversationHistory.tsx
@@ -1,20 +1,37 @@
 import { api } from "@audora/backend/convex/_generated/api";
 import { useQuery } from "convex/react";
-import { ChevronRight, Clock, Inbox, MessageSquare } from "lucide-react";
+import { ChevronRight, Clock, Inbox } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
 import { getConversationDisplayTitle } from "~/lib/conversation-context";
 
 interface ConversationHistoryProps {
   className?: string;
+  headerActions?: ReactNode;
   onScrollBack?: () => void;
 }
 
 export default function ConversationHistory({
   className = "",
+  headerActions,
   onScrollBack,
 }: ConversationHistoryProps) {
   const navigate = useNavigate();
-  const conversations = useQuery(api.conversations.list) || [];
+  const conversations = useQuery(api.conversations.list);
+  const allConversations = conversations || [];
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 6;
+
+  const totalPages = Math.max(1, Math.ceil(allConversations.length / pageSize));
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = startIndex + pageSize;
+  const paginatedConversations = allConversations.slice(startIndex, endIndex);
+
+  useEffect(() => {
+    setCurrentPage((page) => Math.min(page, totalPages));
+  }, [totalPages]);
 
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
@@ -45,22 +62,85 @@ export default function ConversationHistory({
     return getConversationDisplayTitle(conv);
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "active":
-        return "bg-green-500/10 text-green-500 border-green-500/20";
-      case "ended":
-        return "bg-blue-500/10 text-blue-500 border-blue-500/20";
-      case "pending":
-        return "bg-yellow-500/10 text-yellow-500 border-yellow-500/20";
-      default:
-        return "bg-muted-foreground/10 text-muted-foreground border-muted-foreground/20";
+  const getParticipantInitials = (name?: string) => {
+    if (!name) {
+      return "?";
     }
+
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+      return "?";
+    }
+
+    return parts.slice(0, 2).map((part) => part[0]?.toUpperCase() ?? "").join("");
   };
 
+  if (conversations === undefined) {
+    return (
+      <div className={`w-full space-y-5 ${className}`}>
+        {headerActions ? (
+          <div className="flex flex-col gap-3 border-b border-border pb-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex-1" />
+            <div className="flex w-full gap-2 lg:ml-auto lg:w-auto">
+              {headerActions}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="flex min-h-48 items-center justify-center rounded-xl border border-dashed border-border/70 bg-background/40 px-4 py-12">
+          <p className="text-sm text-muted-foreground">Loading conversations...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const showPagination = totalPages > 1;
+  const showToolbar = showPagination || Boolean(headerActions);
+
   return (
-    <div className={`w-full ${className}`}>
-      {conversations.length === 0 ? (
+    <div className={`w-full space-y-5 ${className}`}>
+      {showToolbar ? (
+        <div className="flex flex-col gap-3 border-b border-border pb-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+            {showPagination ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                    disabled={currentPage === 1}>
+                    Previous
+                  </Button>
+                  <span className="min-w-20 text-center text-sm text-muted-foreground">
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                    disabled={currentPage === totalPages}>
+                    Next
+                  </Button>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Showing {startIndex + 1}-{Math.min(endIndex, allConversations.length)} of {allConversations.length} conversations
+                </p>
+              </>
+            ) : null}
+          </div>
+
+          {headerActions ? (
+            <div className="flex w-full gap-2 lg:ml-auto lg:w-auto">
+              {headerActions}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {allConversations.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 px-4">
           <div className="p-4 rounded-full bg-muted mb-4">
             <Inbox className="w-8 h-8 text-muted-foreground" />
@@ -71,40 +151,51 @@ export default function ConversationHistory({
           </p>
         </div>
       ) : (
-        <div className="grid gap-3 sm:gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-          {conversations.map((conversation) => (
-            <div
-              key={conversation._id}
-              onClick={() => {
-                // Route based on conversation status
-                const route = conversation.status === "ended" 
-                  ? `conversations/${conversation._id}`  // View completed conversations
-                  : `record/${conversation._id}`;         // Continue pending/active recordings
-                navigate(route);
-              }}
-              className="group bg-card border border-border rounded-xl p-4 cursor-pointer hover:border-primary/50 hover:shadow-lg transition-all duration-200">
-              <div className="flex items-start justify-between mb-3">
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                    <MessageSquare className="w-4 h-4 text-primary" />
+        <div className="max-h-[50vh] overflow-y-auto pr-1 md:max-h-[34rem]">
+          <div className="grid gap-3 sm:gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+            {paginatedConversations.map((conversation) => (
+              <div
+                key={conversation._id}
+                onClick={() => {
+                  const route =
+                    conversation.status === "ended"
+                      ? `conversations/${conversation._id}`
+                      : `record/${conversation._id}`;
+                  navigate(route);
+                }}
+                className="group bg-card border border-border rounded-xl p-4 cursor-pointer hover:border-primary/50 hover:shadow-lg transition-all duration-200">
+                <div className="flex items-start justify-between mb-3">
+                  <div className="flex items-center">
+                    {conversation.participants.slice(0, 3).map((participant, index) => (
+                      <Avatar
+                        key={participant._id}
+                        className={`size-9 border-2 border-card bg-muted ${index === 0 ? "" : "-ml-2"}`}>
+                        <AvatarImage src={participant.image} alt={participant.name ?? "Participant"} />
+                        <AvatarFallback className="text-[10px] font-medium text-foreground">
+                          {getParticipantInitials(participant.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                    ))}
+                    {conversation.participantCount > 3 ? (
+                      <div className="-ml-2 flex size-9 items-center justify-center rounded-full border-2 border-card bg-muted text-xs font-semibold text-muted-foreground">
+                        +{conversation.participantCount - 3}
+                      </div>
+                    ) : null}
                   </div>
-                  <div className={`px-2 py-0.5 rounded-full text-xs font-medium border ${getStatusColor(conversation.status)}`}>
-                    {conversation.status}
-                  </div>
+                  <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
                 </div>
-                <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
-              </div>
 
-              <h3 className="text-sm font-semibold text-foreground mb-2 line-clamp-1">
-                {getConversationTitle(conversation)}
-              </h3>
+                <h3 className="text-sm font-semibold text-foreground mb-2 line-clamp-1">
+                  {getConversationTitle(conversation)}
+                </h3>
 
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Clock className="w-3 h-3" />
-                <span>{formatDate(conversation._creationTime)}</span>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Clock className="w-3 h-3" />
+                  <span>{formatDate(conversation._creationTime)}</span>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/app/components/analytics/PersonalizedFeedback.tsx
+++ b/apps/web/app/components/analytics/PersonalizedFeedback.tsx
@@ -1,8 +1,8 @@
 import { api } from "@audora/backend/convex/_generated/api";
 import type { Id } from "@audora/backend/convex/_generated/dataModel";
 import { useAction, useQuery } from "convex/react";
-import { Sparkles, Loader2, TrendingUp, Target, Lightbulb, CheckCircle2 } from "lucide-react";
-import { useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2, Sparkles, TrendingUp } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
 
 interface PersonalizedFeedbackProps {
@@ -12,182 +12,176 @@ interface PersonalizedFeedbackProps {
 
 export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFeedbackProps) {
   const [isGenerating, setIsGenerating] = useState(false);
-  
-  // Query for existing feedback
-  const feedback = useQuery(
-    api.analytics.getPersonalizedFeedback,
-    { conversationId, userId }
-  );
-  
+  const [generationFailed, setGenerationFailed] = useState(false);
+  const autoGenerateStarted = useRef(false);
+
+  const feedback = useQuery(api.analytics.getPersonalizedFeedback, {
+    conversationId,
+    userId,
+  });
+
   const generateFeedback = useAction(api.analytics.generatePersonalizedFeedback);
-  
+
   const handleGenerateFeedback = async () => {
     setIsGenerating(true);
+    setGenerationFailed(false);
     try {
-      await generateFeedback({ conversationId, userId });
+      const result = await generateFeedback({ conversationId, userId });
+      if (!result) {
+        setGenerationFailed(true);
+      }
     } catch (error) {
       console.error("Error generating feedback:", error);
+      setGenerationFailed(true);
     } finally {
       setIsGenerating(false);
     }
   };
-  
+
+  useEffect(() => {
+    autoGenerateStarted.current = false;
+    setGenerationFailed(false);
+  }, [conversationId, userId]);
+
+  useEffect(() => {
+    if (feedback !== null || isGenerating || generationFailed || autoGenerateStarted.current) return;
+
+    autoGenerateStarted.current = true;
+    void handleGenerateFeedback();
+  }, [feedback, isGenerating, generationFailed]);
+
   if (feedback === undefined) {
     return (
-      <div className="bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5 rounded-xl p-6 border border-primary/10">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-6">
         <div className="flex items-center justify-center py-4">
-          <Loader2 className="w-6 h-6 text-primary animate-spin" />
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
         </div>
       </div>
     );
   }
-  
+
   if (!feedback) {
     return (
-      <div className="bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5 rounded-xl p-6 border border-primary/10">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-6">
         <div className="flex items-start gap-4">
-          <div className="p-3 bg-primary/10 rounded-lg shrink-0">
-            <Sparkles className="w-6 h-6 text-primary" />
+          <div className="shrink-0 rounded-lg bg-primary/10 p-3">
+            {generationFailed ? (
+              <AlertCircle className="h-6 w-6 text-primary" />
+            ) : (
+              <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            )}
           </div>
           <div className="flex-1">
-            <h3 className="text-lg font-semibold text-foreground mb-2">
-              AI Personalized Feedback
+            <h3 className="mb-2 text-lg font-semibold text-foreground">
+              {generationFailed ? "AI Insights Unavailable" : "Generating AI Insights"}
             </h3>
-            <p className="text-sm text-muted-foreground mb-4">
-              Get personalized insights and actionable recommendations based on your speech patterns, 
-              communication style, and areas for improvement.
+            <p className="mb-4 text-sm text-muted-foreground">
+              {generationFailed
+                ? "We could not generate insights for this conversation yet. This usually means analytics are still being prepared or the AI service is unavailable."
+                : "We are creating personalized insights for this conversation. They will be saved here automatically once ready."}
             </p>
-            <Button
-              onClick={handleGenerateFeedback}
-              disabled={isGenerating}
-              className="gap-2"
-            >
-              {isGenerating ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  Generating...
-                </>
-              ) : (
-                <>
-                  <Sparkles className="w-4 h-4" />
-                  Generate AI Feedback
-                </>
-              )}
-            </Button>
+            {generationFailed && (
+              <Button onClick={handleGenerateFeedback} disabled={isGenerating} className="gap-2">
+                {isGenerating ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Retrying...
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="h-4 w-4" />
+                    Try Again
+                  </>
+                )}
+              </Button>
+            )}
           </div>
         </div>
       </div>
     );
   }
-  
+
+  const needsWorkTitle = feedback.improvements?.[0] || "Keep tightening your delivery";
+  const improvingTitle =
+    feedback.comparisonToPrevious || feedback.actionItems?.[0] || "Building consistency";
+  const strongSkillTitle = feedback.strengths?.[0] || "Clear communication habits";
+
   return (
     <div className="space-y-4">
-      {/* Overall Summary */}
-      <div className="bg-gradient-to-br from-primary/5 via-accent/5 to-primary/5 rounded-xl p-6 border border-primary/10">
-        <div className="flex items-start gap-3 mb-4">
-          <div className="p-2 bg-primary/10 rounded-lg shrink-0">
-            <Sparkles className="w-5 h-5 text-primary" />
+      <div className="rounded-xl border border-primary/10 bg-background/70 p-4">
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 rounded-lg bg-primary/10 p-2">
+            <Sparkles className="h-4 w-4 text-primary" />
           </div>
-          <div className="flex-1">
-            <h3 className="text-base font-semibold text-foreground mb-1">
-              AI Personalized Feedback
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Based on your speech patterns and communication style
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold text-foreground">Personalized Feedback</h3>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {feedback.summary}
             </p>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleGenerateFeedback}
-            disabled={isGenerating}
-            className="gap-1 text-xs"
-          >
-            {isGenerating ? (
-              <Loader2 className="w-3 h-3 animate-spin" />
-            ) : (
-              <Sparkles className="w-3 h-3" />
-            )}
-            Refresh
-          </Button>
-        </div>
-        
-        <div className="prose prose-sm dark:prose-invert max-w-none">
-          <p className="text-sm text-foreground leading-relaxed">
-            {feedback.summary}
-          </p>
         </div>
       </div>
-      
-      {/* Strengths */}
-      {feedback.strengths && feedback.strengths.length > 0 && (
-        <div className="bg-green-500/5 rounded-xl p-5 border border-green-500/10">
-          <div className="flex items-center gap-2 mb-3">
-            <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-500" />
-            <h4 className="text-sm font-semibold text-foreground">Your Strengths</h4>
+
+      <div className="rounded-xl border border-red-500/10 bg-background/80 p-4">
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 rounded-full bg-red-500/10 p-2">
+            <AlertCircle className="h-4 w-4 text-red-500" />
           </div>
-          <ul className="space-y-2">
-            {feedback.strengths.map((strength: string, index: number) => (
-              <li key={index} className="flex items-start gap-2 text-sm text-foreground">
-                <span className="text-green-600 dark:text-green-500 mt-0.5">•</span>
-                <span className="flex-1">{strength}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      
-      {/* Areas for Improvement */}
-      {feedback.improvements && feedback.improvements.length > 0 && (
-        <div className="bg-orange-500/5 rounded-xl p-5 border border-orange-500/10">
-          <div className="flex items-center gap-2 mb-3">
-            <Target className="w-5 h-5 text-orange-600 dark:text-orange-500" />
-            <h4 className="text-sm font-semibold text-foreground">Areas to Improve</h4>
+          <div className="min-w-0 flex-1">
+            <h4 className="text-sm font-semibold text-foreground">Needs Work</h4>
+            <p className="mt-0.5 text-xs font-medium text-red-500">{needsWorkTitle}</p>
+            {feedback.actionItems && feedback.actionItems.length > 0 && (
+              <ul className="mt-2 list-disc space-y-1 pl-4 text-xs leading-relaxed text-muted-foreground">
+                {feedback.actionItems.slice(0, 2).map((item: string, index: number) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            )}
           </div>
-          <ul className="space-y-2">
-            {feedback.improvements.map((improvement: string, index: number) => (
-              <li key={index} className="flex items-start gap-2 text-sm text-foreground">
-                <span className="text-orange-600 dark:text-orange-500 mt-0.5">•</span>
-                <span className="flex-1">{improvement}</span>
-              </li>
-            ))}
-          </ul>
         </div>
-      )}
-      
-      {/* Action Items */}
-      {feedback.actionItems && feedback.actionItems.length > 0 && (
-        <div className="bg-blue-500/5 rounded-xl p-5 border border-blue-500/10">
-          <div className="flex items-center gap-2 mb-3">
-            <Lightbulb className="w-5 h-5 text-blue-600 dark:text-blue-500" />
-            <h4 className="text-sm font-semibold text-foreground">Action Items</h4>
+      </div>
+
+      <div className="rounded-xl border border-yellow-500/10 bg-background/80 p-4">
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 rounded-full bg-yellow-500/10 p-2">
+            <TrendingUp className="h-4 w-4 text-yellow-500" />
           </div>
-          <ul className="space-y-2.5">
-            {feedback.actionItems.map((item: string, index: number) => (
-              <li key={index} className="flex items-start gap-2.5 text-sm">
-                <div className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-500/10 text-blue-600 dark:text-blue-500 text-xs font-semibold shrink-0 mt-0.5">
-                  {index + 1}
-                </div>
-                <span className="flex-1 text-foreground">{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      
-      {/* Progress Tracking */}
-      {feedback.comparisonToPrevious && (
-        <div className="bg-purple-500/5 rounded-xl p-5 border border-purple-500/10">
-          <div className="flex items-center gap-2 mb-3">
-            <TrendingUp className="w-5 h-5 text-purple-600 dark:text-purple-500" />
-            <h4 className="text-sm font-semibold text-foreground">Your Progress</h4>
+          <div className="min-w-0 flex-1">
+            <h4 className="text-sm font-semibold text-foreground">Currently Improving</h4>
+            <p className="mt-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400">
+              {improvingTitle}
+            </p>
+            {feedback.improvements && feedback.improvements.length > 1 && (
+              <ul className="mt-2 list-disc space-y-1 pl-4 text-xs leading-relaxed text-muted-foreground">
+                {feedback.improvements.slice(1, 3).map((item: string, index: number) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            )}
           </div>
-          <p className="text-sm text-foreground leading-relaxed">
-            {feedback.comparisonToPrevious}
-          </p>
         </div>
-      )}
+      </div>
+
+      <div className="rounded-xl border border-green-500/10 bg-background/80 p-4">
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 rounded-full bg-green-500/10 p-2">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h4 className="text-sm font-semibold text-foreground">Strong Skill</h4>
+            <p className="mt-0.5 text-xs font-medium text-green-600 dark:text-green-400">
+              {strongSkillTitle}
+            </p>
+            {feedback.strengths && feedback.strengths.length > 1 && (
+              <ul className="mt-2 list-disc space-y-1 pl-4 text-xs leading-relaxed text-muted-foreground">
+                {feedback.strengths.slice(1, 3).map((item: string, index: number) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
-

--- a/apps/web/app/components/analytics/PersonalizedFeedback.tsx
+++ b/apps/web/app/components/analytics/PersonalizedFeedback.tsx
@@ -52,7 +52,7 @@ export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFee
 
   if (feedback === undefined) {
     return (
-      <div className="rounded-xl border border-primary/10 bg-primary/5 p-6">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-6 dark:border-primary/15 dark:bg-primary/[0.08]">
         <div className="flex items-center justify-center py-4">
           <Loader2 className="h-6 w-6 animate-spin text-primary" />
         </div>
@@ -62,7 +62,7 @@ export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFee
 
   if (!feedback) {
     return (
-      <div className="rounded-xl border border-primary/10 bg-primary/5 p-6">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-6 dark:border-primary/15 dark:bg-primary/[0.08]">
         <div className="flex items-start gap-4">
           <div className="shrink-0 rounded-lg bg-primary/10 p-3">
             {generationFailed ? (
@@ -108,7 +108,7 @@ export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFee
 
   return (
     <div className="space-y-4">
-      <div className="rounded-xl border border-primary/10 bg-background/70 p-4">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-4 dark:border-primary/15 dark:bg-primary/[0.08]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 rounded-lg bg-primary/10 p-2">
             <Sparkles className="h-4 w-4 text-primary" />
@@ -122,7 +122,7 @@ export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFee
         </div>
       </div>
 
-      <div className="rounded-xl border border-red-500/10 bg-background/80 p-4">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-4 dark:border-primary/15 dark:bg-primary/[0.08]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 rounded-full bg-red-500/10 p-2">
             <AlertCircle className="h-4 w-4 text-red-500" />
@@ -141,7 +141,7 @@ export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFee
         </div>
       </div>
 
-      <div className="rounded-xl border border-yellow-500/10 bg-background/80 p-4">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-4 dark:border-primary/15 dark:bg-primary/[0.08]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 rounded-full bg-yellow-500/10 p-2">
             <TrendingUp className="h-4 w-4 text-yellow-500" />
@@ -162,7 +162,7 @@ export function PersonalizedFeedback({ conversationId, userId }: PersonalizedFee
         </div>
       </div>
 
-      <div className="rounded-xl border border-green-500/10 bg-background/80 p-4">
+      <div className="rounded-xl border border-primary/10 bg-primary/5 p-4 dark:border-primary/15 dark:bg-primary/[0.08]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 rounded-full bg-green-500/10 p-2">
             <CheckCircle2 className="h-4 w-4 text-green-500" />

--- a/apps/web/app/components/dashboard/analytics-panel.tsx
+++ b/apps/web/app/components/dashboard/analytics-panel.tsx
@@ -538,11 +538,11 @@ export function AnalyticsPanel({
         <h2 className="text-lg font-semibold text-foreground mb-4 shrink-0">Analytics</h2>
       )}
 
-      <Tabs defaultValue="overview" className="flex flex-col h-full min-h-0">
+      <Tabs defaultValue="delivery" className="flex flex-col h-full min-h-0">
         <TabsList className="shrink-0 mb-4">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="word-choice">Word Choice</TabsTrigger>
           <TabsTrigger value="delivery">Delivery</TabsTrigger>
+          <TabsTrigger value="word-choice">Word Choice</TabsTrigger>
+          <TabsTrigger value="overview">Feedback</TabsTrigger>
         </TabsList>
 
         {/* Overview Tab - AI Feedback */}

--- a/apps/web/app/components/dashboard/analytics-panel.tsx
+++ b/apps/web/app/components/dashboard/analytics-panel.tsx
@@ -568,6 +568,15 @@ export function AnalyticsPanel({
     }
   }, [weakWordExampleIndex, weakWordExamples.length]);
 
+  const actionableInsightsContent = currentUser ? (
+    <PersonalizedFeedback
+      conversationId={conversationId}
+      userId={currentUser._id}
+    />
+  ) : (
+    <p className="text-sm text-muted-foreground">Sign in to view personalized insights.</p>
+  );
+
   // Loading state
   if (!conversationId) {
     return (
@@ -818,7 +827,7 @@ export function AnalyticsPanel({
 
             </div>
 
-            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-border bg-sidebar p-5 shadow-sm dark:bg-card">
+            <aside className="hidden h-full min-h-0 flex-col rounded-xl border border-border bg-sidebar p-5 shadow-sm dark:bg-card xl:flex">
               <div className="shrink-0 border-b border-border/70 pb-3">
                 <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
                 <p className="mt-1 text-sm text-muted-foreground">
@@ -826,14 +835,7 @@ export function AnalyticsPanel({
                 </p>
               </div>
               <div className="mt-4 min-h-0 flex-1 overflow-y-auto pr-2 custom-scrollbar">
-                {currentUser ? (
-                  <PersonalizedFeedback
-                    conversationId={conversationId}
-                    userId={currentUser._id}
-                  />
-                ) : (
-                  <p className="text-sm text-muted-foreground">Sign in to view personalized insights.</p>
-                )}
+                {actionableInsightsContent}
               </div>
             </aside>
           </div>

--- a/apps/web/app/components/dashboard/analytics-panel.tsx
+++ b/apps/web/app/components/dashboard/analytics-panel.tsx
@@ -274,7 +274,7 @@ function PacingVariationChart({
 
   return (
     <div className="mt-2">
-      <div className="relative rounded-lg bg-muted/20 p-2">
+      <div className="relative p-2">
         <div className="flex items-start">
           {/* Y-axis labels */}
           <div className="flex-shrink-0 pb-4">
@@ -626,7 +626,7 @@ export function AnalyticsPanel({
 
         <TabsContent value="summary" className="flex-1 min-h-0 overflow-hidden">
           <div className="grid h-full min-h-0 gap-5 overflow-hidden xl:grid-cols-[minmax(0,1fr)_22rem]">
-            <div className="grid min-h-0 auto-rows-[minmax(14rem,auto)] items-stretch gap-4 overflow-y-auto pr-3 custom-scrollbar md:grid-cols-2 xl:grid-cols-6">
+            <div className="grid min-h-0 auto-rows-[minmax(14rem,auto)] items-stretch gap-4 overflow-y-auto custom-scrollbar md:grid-cols-2 xl:grid-cols-6">
               <section className="flex min-h-[14rem] flex-col rounded-xl border border-border bg-card p-5 shadow-sm xl:col-span-3">
                 <div className="flex items-center justify-between border-b border-border/70 pb-3">
                   <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -736,7 +736,7 @@ export function AnalyticsPanel({
                 </p>
                 <div className="mt-4 pb-3">
                   {selectedWeakWordExample ? (
-                    <div className="rounded-lg bg-muted/35 p-3">
+                    <div className="p-3">
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0 flex-1">
                           <p className="text-xs text-muted-foreground">
@@ -815,10 +815,11 @@ export function AnalyticsPanel({
                   ))}
                 </div>
               </section>
+
             </div>
 
-            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm">
-              <div className="shrink-0 border-b border-primary/20 pb-3">
+            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-border bg-sidebar p-5 shadow-sm dark:bg-card">
+              <div className="shrink-0 border-b border-border/70 pb-3">
                 <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Focus areas from this conversation.

--- a/apps/web/app/components/dashboard/analytics-panel.tsx
+++ b/apps/web/app/components/dashboard/analytics-panel.tsx
@@ -2,6 +2,7 @@ import { api } from "@audora/backend/convex/_generated/api";
 import type { Id } from "@audora/backend/convex/_generated/dataModel";
 import { useAction, useMutation, useQuery } from "convex/react";
 import {
+    ChevronLeft,
     ChevronRight,
     Clock,
     Loader2,
@@ -22,6 +23,26 @@ function formatTimestamp(seconds: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = Math.floor(seconds % 60);
   return `${mins}:${String(secs).padStart(2, '0')}`;
+}
+
+function getWeakWordSnippet(sentence: string, word: string, maxLength = 96): string {
+  const normalizedSentence = sentence.trim().replace(/\s+/g, " ");
+  if (normalizedSentence.length <= maxLength) return normalizedSentence;
+
+  const wordIndex = normalizedSentence.toLowerCase().indexOf(word.toLowerCase());
+  if (wordIndex === -1) {
+    return `${normalizedSentence.slice(0, maxLength - 3).trimEnd()}...`;
+  }
+
+  const targetStart = Math.max(0, wordIndex - Math.floor((maxLength - word.length) / 2));
+  const targetEnd = Math.min(normalizedSentence.length, targetStart + maxLength);
+  const start = Math.max(0, targetEnd - maxLength);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = targetEnd < normalizedSentence.length ? "..." : "";
+  const availableLength = maxLength - prefix.length - suffix.length;
+  const snippet = normalizedSentence.slice(start, start + availableLength).trim();
+
+  return `${prefix}${snippet}${suffix}`;
 }
 
 // Clickable timestamp button component
@@ -235,119 +256,140 @@ function PacingVariationChart({
   // Calculate Y positions as percentages for HTML labels
   const y160Percent = (zoneTop / height) * 100;
   const y100Percent = (zoneBottom / height) * 100;
+  const hoveredPoint = hoveredIndex !== null ? pointCoords[hoveredIndex] : null;
+  const hoveredXPercent = hoveredPoint ? (hoveredPoint.x / width) * 100 : 0;
+  const hoveredYPercent = hoveredPoint ? (hoveredPoint.y / height) * 100 : 0;
+  const tooltipLeft =
+    hoveredXPercent < 12
+      ? "0.5rem"
+      : hoveredXPercent > 88
+        ? "calc(100% - 0.5rem)"
+        : `${hoveredXPercent}%`;
+  const tooltipXTransform =
+    hoveredXPercent < 12
+      ? "translateX(0)"
+      : hoveredXPercent > 88
+        ? "translateX(-100%)"
+        : "translateX(-50%)";
 
   return (
     <div className="mt-2">
-      <div className="flex items-center gap-2 mb-1">
-        <h5 className="text-sm font-medium text-foreground">Pacing Variation</h5>
-        <div className="flex items-center gap-1">
-          <div className="w-3 h-2 bg-primary/20 rounded-sm" />
-          <span className="text-[10px] text-muted-foreground">Conversational (100-160)</span>
-        </div>
-      </div>
-      <div className="relative bg-muted/20 rounded-lg p-2">
-        {/* Chart with Y-axis labels */}
-        <div className="flex">
+      <div className="relative rounded-lg bg-muted/20 p-2">
+        <div className="flex items-start">
           {/* Y-axis labels */}
-          <div className="relative w-8 h-20 flex-shrink-0 text-[10px] text-muted-foreground">
-            <span className="absolute right-1 top-0 -translate-y-1/2">{maxVal}</span>
-            <span className="absolute right-1 text-primary/70" style={{ top: `${y160Percent}%`, transform: 'translateY(-50%)' }}>160</span>
-            <span className="absolute right-1 text-primary/70" style={{ top: `${y100Percent}%`, transform: 'translateY(-50%)' }}>100</span>
-            <span className="absolute right-1 bottom-0 translate-y-1/2">{minVal}</span>
-          </div>
-          {/* Chart area */}
-          <div className="flex-1 relative">
-            <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-20" preserveAspectRatio="none">
-              {/* Conversational zone highlight (always shown at 100-160 WPM) */}
-              <rect
-              x="0"
-              y={zoneTop}
-              width={width}
-              height={zoneHeight}
-              fill="currentColor"
-              className="text-primary/10"
-            />
-            {/* Grid lines at 100 and 160 WPM boundaries */}
-            <line x1="0" y1={zoneTop} x2={width} y2={zoneTop} stroke="currentColor" strokeWidth="0.5" className="text-muted-foreground/30" strokeDasharray="2,2" style={{ pointerEvents: 'none' }} />
-            <line x1="0" y1={zoneBottom} x2={width} y2={zoneBottom} stroke="currentColor" strokeWidth="0.5" className="text-muted-foreground/30" strokeDasharray="2,2" style={{ pointerEvents: 'none' }} />
-            {/* Smooth line chart */}
-            <path
-              d={smoothPath}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="text-primary"
-              vectorEffect="non-scaling-stroke"
-              style={{ pointerEvents: 'none' }}
-            />
-            {/* Hover vertical line */}
-            {hoveredIndex !== null && (
-              <line
-                x1={pointCoords[hoveredIndex].x}
-                y1={0}
-                x2={pointCoords[hoveredIndex].x}
-                y2={height}
-                stroke="currentColor"
-                strokeWidth="0.5"
-                className="text-muted-foreground"
-                strokeDasharray="2,1"
-                vectorEffect="non-scaling-stroke"
-                style={{ pointerEvents: 'none' }}
-              />
-            )}
-            {/* Interactive hover areas */}
-            {pointCoords.map((point, i) => (
-              <rect
-                key={i}
-                x={point.x - (width / data.length / 2)}
-                y={0}
-                width={width / data.length}
-                height={height}
-                fill="transparent"
-                className="cursor-pointer"
-                onMouseEnter={() => setHoveredIndex(i)}
-                onMouseLeave={() => setHoveredIndex(null)}
-              />
-            ))}
-            {/* Hover point indicator */}
-            {hoveredIndex !== null && (
-              <circle
-                cx={pointCoords[hoveredIndex].x}
-                cy={pointCoords[hoveredIndex].y}
-                r="3"
-                fill="currentColor"
-                className="text-primary"
-                vectorEffect="non-scaling-stroke"
-                style={{ pointerEvents: 'none' }}
-              />
-            )}
-          </svg>
-          {/* Tooltip */}
-          {hoveredIndex !== null && (
-            <div
-              className="absolute bg-popover text-popover-foreground border border-border rounded-md px-2 py-1 text-xs shadow-md pointer-events-none z-10"
-              style={{
-                left: `${(pointCoords[hoveredIndex].x / width) * 100}%`,
-                top: `${(pointCoords[hoveredIndex].y / height) * 100}%`,
-                transform: 'translate(-50%, -120%)'
-              }}
-            >
-              <div className="font-medium">{pointCoords[hoveredIndex].value} WPM</div>
-              <div className="text-muted-foreground">{pointCoords[hoveredIndex].time}</div>
+          <div className="flex-shrink-0 pb-4">
+            <div className="relative h-16 w-12 text-[10px] text-muted-foreground">
+              <span className="absolute right-3 text-primary/70" style={{ top: `${y160Percent}%`, transform: "translateY(-50%)" }}>160</span>
+              <span className="absolute right-3 text-primary/70" style={{ top: `${y100Percent}%`, transform: "translateY(-50%)" }}>100</span>
             </div>
-          )}
-          {/* X-axis labels */}
-          <div className="flex justify-between text-[10px] text-muted-foreground mt-1">
-            {timeLabels.map((label, i) => (
-              <span key={i}>{label}</span>
-            ))}
           </div>
+          <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+            <div className="min-w-[560px] pb-0.5">
+              {/* Chart area */}
+              <div className="relative h-16 overflow-hidden">
+                <svg viewBox={`0 0 ${width} ${height}`} className="h-16 w-full" preserveAspectRatio="none">
+                  <defs>
+                    <clipPath id="pacing-chart-clip">
+                      <rect x="0" y="0" width={width} height={height} />
+                    </clipPath>
+                  </defs>
+                  {/* Conversational zone highlight (always shown at 100-160 WPM) */}
+                  <rect
+                    x="0"
+                    y={zoneTop}
+                    width={width}
+                    height={zoneHeight}
+                    fill="currentColor"
+                    className="text-primary/10"
+                  />
+                  {/* Grid lines at 100 and 160 WPM boundaries */}
+                  <line x1="0" y1={zoneTop} x2={width} y2={zoneTop} stroke="currentColor" strokeWidth="0.5" className="text-muted-foreground/30" strokeDasharray="2,2" style={{ pointerEvents: 'none' }} />
+                  <line x1="0" y1={zoneBottom} x2={width} y2={zoneBottom} stroke="currentColor" strokeWidth="0.5" className="text-muted-foreground/30" strokeDasharray="2,2" style={{ pointerEvents: 'none' }} />
+                  {/* Smooth line chart */}
+                  <path
+                    d={smoothPath}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    className="text-primary"
+                    clipPath="url(#pacing-chart-clip)"
+                    vectorEffect="non-scaling-stroke"
+                    style={{ pointerEvents: 'none' }}
+                  />
+                  {/* Hover vertical line */}
+                  {hoveredIndex !== null && (
+                    <line
+                      x1={pointCoords[hoveredIndex].x}
+                      y1={0}
+                      x2={pointCoords[hoveredIndex].x}
+                      y2={height}
+                      stroke="currentColor"
+                      strokeWidth="0.5"
+                      className="text-muted-foreground"
+                      strokeDasharray="2,1"
+                      clipPath="url(#pacing-chart-clip)"
+                      vectorEffect="non-scaling-stroke"
+                      style={{ pointerEvents: 'none' }}
+                    />
+                  )}
+                  {/* Interactive hover areas */}
+                  {pointCoords.map((point, i) => (
+                    <rect
+                      key={i}
+                      x={point.x - (width / data.length / 2)}
+                      y={0}
+                      width={width / data.length}
+                      height={height}
+                      fill="transparent"
+                      className="cursor-pointer"
+                      onMouseEnter={() => setHoveredIndex(i)}
+                      onMouseLeave={() => setHoveredIndex(null)}
+                    />
+                  ))}
+                  {/* Hover point indicator */}
+                  {hoveredIndex !== null && (
+                    <circle
+                      cx={pointCoords[hoveredIndex].x}
+                      cy={pointCoords[hoveredIndex].y}
+                      r="3"
+                      fill="currentColor"
+                      className="text-primary"
+                      clipPath="url(#pacing-chart-clip)"
+                      vectorEffect="non-scaling-stroke"
+                      style={{ pointerEvents: 'none' }}
+                    />
+                  )}
+                </svg>
+                {/* Tooltip */}
+                {hoveredIndex !== null && (
+                  <div
+                    className="absolute z-10 rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md pointer-events-none"
+                    style={{
+                      left: tooltipLeft,
+                      top: `clamp(0.25rem, ${hoveredYPercent}%, calc(100% - 2.75rem))`,
+                      transform: tooltipXTransform
+                    }}
+                  >
+                    <div className="font-medium">{pointCoords[hoveredIndex].value} WPM</div>
+                    <div className="text-muted-foreground">{pointCoords[hoveredIndex].time}</div>
+                  </div>
+                )}
+              </div>
+              {/* X-axis labels */}
+              <div className="mt-1 grid grid-flow-col auto-cols-fr px-1 text-[10px] leading-none text-muted-foreground">
+                {timeLabels.map((label, i) => (
+                  <span
+                    key={i}
+                    className={i === 0 ? "text-left" : i === timeLabels.length - 1 ? "text-right" : "text-center"}
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>
-      <p className="text-xs text-muted-foreground mt-1">
-        <span className="font-medium">Vary your pace</span> to keep your audience engaged. <span className="font-medium">Practice sections</span> where your pace is flat.
-      </p>
     </div>
   );
 }
@@ -356,15 +398,18 @@ interface AnalyticsPanelProps {
   showHeader?: boolean;
   className?: string;
   conversationId?: Id<"conversations">;
+  onOpenTranscript?: () => void;
 }
 
 export function AnalyticsPanel({
   showHeader = true,
   className,
   conversationId,
+  onOpenTranscript,
 }: AnalyticsPanelProps) {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [isGeneratingSuggestions, setIsGeneratingSuggestions] = useState(false);
+  const [weakWordExampleIndex, setWeakWordExampleIndex] = useState(0);
 
   // Audio playback context for syncing with transcript
   const audioPlayback = useAudioPlaybackOptional();
@@ -415,6 +460,8 @@ export function AnalyticsPanel({
 
   // Handle seeking to a timestamp
   const handleSeekToTime = (time: number, wordId?: string) => {
+    onOpenTranscript?.();
+
     if (audioPlayback) {
       if (wordId) {
         // Set highlighted word ID - this will trigger the TranscriptPlayer to seek and highlight
@@ -427,6 +474,22 @@ export function AnalyticsPanel({
 
   const analyzeUserSpeech = useMutation(api.analytics.analyzeUserSpeech);
   const generateSuggestions = useAction(api.analytics.generateWeakWordSuggestions);
+
+  const handleGenerateSuggestions = async () => {
+    if (!conversationId || !currentUser) return;
+
+    setIsGeneratingSuggestions(true);
+    try {
+      await generateSuggestions({
+        conversationId,
+        userId: currentUser._id,
+      });
+    } catch (error) {
+      console.error("Error generating suggestions:", error);
+    } finally {
+      setIsGeneratingSuggestions(false);
+    }
+  };
 
   // Auto-analyze if no analytics exist
   useEffect(() => {
@@ -454,22 +517,6 @@ export function AnalyticsPanel({
 
     runAnalysis();
   }, [conversationId, currentUser?._id, currentUserAnalytics.length, conversationAnalytics, analyzeUserSpeech]);
-
-  const handleGenerateSuggestions = async () => {
-    if (!conversationId || !currentUser) return;
-
-    setIsGeneratingSuggestions(true);
-    try {
-      await generateSuggestions({
-        conversationId,
-        userId: currentUser._id,
-      });
-    } catch (error) {
-      console.error("Error generating suggestions:", error);
-    } finally {
-      setIsGeneratingSuggestions(false);
-    }
-  };
 
   const getScoreColor = (score: number) => {
     if (score >= 80) return "text-green-500";
@@ -508,6 +555,18 @@ export function AnalyticsPanel({
         ? "Your pace was fast. Try slowing down to under 160 WPM."
         : "Great pace. Keep it between 100-160 WPM for clarity."
     : "";
+
+  const weakWordExamples = analytics?.weakWords || [];
+  const selectedWeakWordExample =
+    weakWordExamples.length > 0
+      ? weakWordExamples[weakWordExampleIndex % weakWordExamples.length]
+      : null;
+
+  useEffect(() => {
+    if (weakWordExampleIndex >= weakWordExamples.length) {
+      setWeakWordExampleIndex(0);
+    }
+  }, [weakWordExampleIndex, weakWordExamples.length]);
 
   // Loading state
   if (!conversationId) {
@@ -566,21 +625,25 @@ export function AnalyticsPanel({
         </TabsList>
 
         <TabsContent value="summary" className="flex-1 min-h-0 overflow-hidden">
-          <div className="grid h-full min-h-0 gap-5 overflow-y-auto pr-3 custom-scrollbar xl:grid-cols-[minmax(0,1fr)_22rem]">
-            <div className="space-y-4">
-              <section className="rounded-xl border border-border bg-card p-4 shadow-sm">
-                <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="min-w-0">
+          <div className="grid h-full min-h-0 gap-5 overflow-hidden xl:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="grid min-h-0 auto-rows-[minmax(14rem,auto)] items-stretch gap-4 overflow-y-auto pr-3 custom-scrollbar md:grid-cols-2 xl:grid-cols-6">
+              <section className="flex min-h-[14rem] flex-col rounded-xl border border-border bg-card p-5 shadow-sm xl:col-span-3">
+                <div className="flex items-center justify-between border-b border-border/70 pb-3">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
                     <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                       Pace of Speech
                     </p>
-                    <p className="mt-1 text-sm text-muted-foreground">{pacingMessage}</p>
+                    <span className="inline-flex items-center gap-1 text-[10px] font-medium normal-case tracking-normal text-muted-foreground">
+                      <span className="h-2 w-3 rounded-sm bg-primary/20" />
+                      Conversational (100-160)
+                    </span>
                   </div>
-                  <p className="text-2xl font-semibold text-foreground sm:text-right">
+                  <span className="shrink-0 text-sm font-semibold text-foreground">
                     {analytics.pacing.wordsPerMinute}
-                    <span className="ml-1 text-sm font-normal text-muted-foreground">words/min</span>
-                  </p>
+                    <span className="ml-1 font-normal text-muted-foreground">words/min</span>
+                  </span>
                 </div>
+                <p className="mt-3 text-sm text-muted-foreground">{pacingMessage}</p>
                 <PacingVariationChart
                   wpm={analytics.pacing.wordsPerMinute}
                   segments={analytics.pacing.segments}
@@ -588,8 +651,7 @@ export function AnalyticsPanel({
                 />
               </section>
 
-              <div className="grid auto-rows-fr gap-4 md:grid-cols-5">
-              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-2">
+              <section className="flex min-h-[14rem] flex-col rounded-xl border border-border bg-card p-5 shadow-sm xl:col-span-3">
                 <div className="flex items-center justify-between border-b border-border/70 pb-3">
                   <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     Filler Words
@@ -636,7 +698,7 @@ export function AnalyticsPanel({
                 )}
               </section>
 
-              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-3">
+              <section className="flex min-h-[14rem] flex-col rounded-xl border border-border bg-card p-5 shadow-sm xl:col-span-2">
                 <div className="flex items-center justify-between border-b border-border/70 pb-3">
                   <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     Repetition
@@ -647,10 +709,7 @@ export function AnalyticsPanel({
                   {repeatedWordCount}
                   <span className="ml-1 text-sm font-normal text-muted-foreground">instances</span>
                 </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Repeated words can make speech feel less concise.
-                </p>
-                <div className="mt-4 space-y-2">
+                <div className="mt-4 space-y-2 pb-3">
                   {analytics.repetitions.repeatedWords.length > 0 ? (
                     analytics.repetitions.repeatedWords.slice(0, 4).map((item) => (
                       <div key={item.word} className="flex items-center justify-between text-sm">
@@ -664,7 +723,7 @@ export function AnalyticsPanel({
                 </div>
               </section>
 
-              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-3">
+              <section className="flex min-h-[14rem] flex-col rounded-xl border border-border bg-card p-5 shadow-sm xl:col-span-2">
                 <div className="flex items-center justify-between border-b border-border/70 pb-3">
                   <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     Weak Words
@@ -675,46 +734,63 @@ export function AnalyticsPanel({
                   {analytics.weakWords.length}
                   <span className="ml-1 text-sm font-normal text-muted-foreground">found</span>
                 </p>
-                <div className="mt-4 space-y-3">
-                  {analytics.weakWords.length > 0 ? (
-                    analytics.weakWords.slice(0, 2).map((item, index) => (
-                      <div key={index} className="rounded-lg bg-muted/35 p-3">
-                        <p className="text-xs text-muted-foreground">
-                          Weak word: <span className="font-medium text-foreground">"{item.word}"</span>
-                        </p>
-                        <p className="mt-1 line-clamp-2 text-xs italic text-foreground/80">
-                          "{item.sentence}"
-                        </p>
-                        {item.suggestion && (
-                          <p className="mt-2 text-xs font-medium text-primary">
-                            -&gt; "{item.suggestion}"
+                <div className="mt-4 pb-3">
+                  {selectedWeakWordExample ? (
+                    <div className="rounded-lg bg-muted/35 p-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs text-muted-foreground">
+                            Weak word:{" "}
+                            <span className="font-medium text-foreground">
+                              "{selectedWeakWordExample.word}"
+                            </span>
                           </p>
-                        )}
+                          <p
+                            className="mt-1 truncate text-xs italic text-foreground/80"
+                            title={selectedWeakWordExample.sentence}
+                          >
+                            "{getWeakWordSnippet(
+                              selectedWeakWordExample.sentence,
+                              selectedWeakWordExample.word
+                            )}"
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setWeakWordExampleIndex((index) =>
+                                (index - 1 + weakWordExamples.length) % weakWordExamples.length
+                              )
+                            }
+                            className="rounded-md border border-border bg-background p-1 text-muted-foreground transition-colors hover:text-foreground"
+                            aria-label="Previous weak word example"
+                          >
+                            <ChevronLeft className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setWeakWordExampleIndex((index) => (index + 1) % weakWordExamples.length)
+                            }
+                            className="rounded-md border border-border bg-background p-1 text-muted-foreground transition-colors hover:text-foreground"
+                            aria-label="Next weak word example"
+                          >
+                            <ChevronRight className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
                       </div>
-                    ))
+                      <p className="mt-3 text-[11px] text-muted-foreground">
+                        {weakWordExampleIndex + 1} of {weakWordExamples.length}
+                      </p>
+                    </div>
                   ) : (
                     <p className="text-sm text-muted-foreground">No weak words detected.</p>
-                  )}
-                  {analytics.weakWords.some((word) => !word.suggestion) && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={handleGenerateSuggestions}
-                      disabled={isGeneratingSuggestions}
-                      className="h-8 w-full text-xs"
-                    >
-                      {isGeneratingSuggestions ? (
-                        <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                      ) : (
-                        <Sparkles className="mr-1 h-3 w-3" />
-                      )}
-                      Generate AI Suggestions
-                    </Button>
                   )}
                 </div>
               </section>
 
-              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-2">
+              <section className="flex min-h-[14rem] flex-col rounded-xl border border-border bg-card p-5 shadow-sm xl:col-span-2">
                 <div className="flex items-center justify-between border-b border-border/70 pb-3">
                   <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     Sentence Starters
@@ -730,7 +806,7 @@ export function AnalyticsPanel({
                     ? `"${topSentenceStarter.word}" showed up most often.`
                     : "No weak sentence starters detected."}
                 </p>
-                <div className="mt-4 space-y-2">
+                <div className="mt-4 space-y-2 pb-3">
                   {analytics.sentenceStarters.weak.slice(0, 4).map((item) => (
                     <div key={item.word} className="flex items-center justify-between text-sm">
                       <span className="text-muted-foreground">"{item.word}"</span>
@@ -739,24 +815,25 @@ export function AnalyticsPanel({
                   ))}
                 </div>
               </section>
-              </div>
             </div>
 
-            <aside className="rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm xl:sticky xl:top-0 xl:self-start">
-              <div className="mb-4 border-b border-primary/20 pb-3">
+            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm">
+              <div className="shrink-0 border-b border-primary/20 pb-3">
                 <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Focus areas from this conversation.
                 </p>
               </div>
-              {currentUser ? (
-                <PersonalizedFeedback
-                  conversationId={conversationId}
-                  userId={currentUser._id}
-                />
-              ) : (
-                <p className="text-sm text-muted-foreground">Sign in to view personalized insights.</p>
-              )}
+              <div className="mt-4 min-h-0 flex-1 overflow-y-auto pr-2 custom-scrollbar">
+                {currentUser ? (
+                  <PersonalizedFeedback
+                    conversationId={conversationId}
+                    userId={currentUser._id}
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">Sign in to view personalized insights.</p>
+                )}
+              </div>
             </aside>
           </div>
         </TabsContent>

--- a/apps/web/app/components/dashboard/analytics-panel.tsx
+++ b/apps/web/app/components/dashboard/analytics-panel.tsx
@@ -568,7 +568,7 @@ export function AnalyticsPanel({
     }
   }, [weakWordExampleIndex, weakWordExamples.length]);
 
-  const actionableInsightsContent = currentUser ? (
+  const actionableInsightsContent = currentUser && conversationId ? (
     <PersonalizedFeedback
       conversationId={conversationId}
       userId={currentUser._id}

--- a/apps/web/app/components/dashboard/analytics-panel.tsx
+++ b/apps/web/app/components/dashboard/analytics-panel.tsx
@@ -237,8 +237,8 @@ function PacingVariationChart({
   const y100Percent = (zoneBottom / height) * 100;
 
   return (
-    <div className="mt-4">
-      <div className="flex items-center gap-2 mb-2">
+    <div className="mt-2">
+      <div className="flex items-center gap-2 mb-1">
         <h5 className="text-sm font-medium text-foreground">Pacing Variation</h5>
         <div className="flex items-center gap-1">
           <div className="w-3 h-2 bg-primary/20 rounded-sm" />
@@ -249,7 +249,7 @@ function PacingVariationChart({
         {/* Chart with Y-axis labels */}
         <div className="flex">
           {/* Y-axis labels */}
-          <div className="relative w-8 h-24 flex-shrink-0 text-[10px] text-muted-foreground">
+          <div className="relative w-8 h-20 flex-shrink-0 text-[10px] text-muted-foreground">
             <span className="absolute right-1 top-0 -translate-y-1/2">{maxVal}</span>
             <span className="absolute right-1 text-primary/70" style={{ top: `${y160Percent}%`, transform: 'translateY(-50%)' }}>160</span>
             <span className="absolute right-1 text-primary/70" style={{ top: `${y100Percent}%`, transform: 'translateY(-50%)' }}>100</span>
@@ -257,7 +257,7 @@ function PacingVariationChart({
           </div>
           {/* Chart area */}
           <div className="flex-1 relative">
-            <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-24" preserveAspectRatio="none">
+            <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-20" preserveAspectRatio="none">
               {/* Conversational zone highlight (always shown at 100-160 WPM) */}
               <rect
               x="0"
@@ -345,7 +345,7 @@ function PacingVariationChart({
           </div>
         </div>
       </div>
-      <p className="text-xs text-muted-foreground mt-2">
+      <p className="text-xs text-muted-foreground mt-1">
         <span className="font-medium">Vary your pace</span> to keep your audience engaged. <span className="font-medium">Practice sections</span> where your pace is flat.
       </p>
     </div>
@@ -489,6 +489,26 @@ export function AnalyticsPanel({
     return <TrendingDown className="w-4 h-4 text-red-500" />;
   };
 
+  const repeatedWordCount = analytics?.repetitions.repeatedWords.reduce(
+    (sum, word) => sum + word.count,
+    0
+  ) ?? 0;
+
+  const sentenceStarterTotal = analytics?.sentenceStarters.weak.reduce(
+    (sum, starter) => sum + starter.count,
+    0
+  ) ?? 0;
+
+  const topSentenceStarter = analytics?.sentenceStarters.weak[0];
+
+  const pacingMessage = analytics
+    ? analytics.pacing.wordsPerMinute < 100
+      ? "Your pace was slow. Try speaking faster than 120 WPM."
+      : analytics.pacing.wordsPerMinute > 160
+        ? "Your pace was fast. Try slowing down to under 160 WPM."
+        : "Great pace. Keep it between 100-160 WPM for clarity."
+    : "";
+
   // Loading state
   if (!conversationId) {
     return (
@@ -538,12 +558,208 @@ export function AnalyticsPanel({
         <h2 className="text-lg font-semibold text-foreground mb-4 shrink-0">Analytics</h2>
       )}
 
-      <Tabs defaultValue="delivery" className="flex flex-col h-full min-h-0">
-        <TabsList className="shrink-0 mb-4">
+      <Tabs defaultValue="summary" className="flex flex-col h-full min-h-0">
+        <TabsList className="hidden">
           <TabsTrigger value="delivery">Delivery</TabsTrigger>
           <TabsTrigger value="word-choice">Word Choice</TabsTrigger>
           <TabsTrigger value="overview">Feedback</TabsTrigger>
         </TabsList>
+
+        <TabsContent value="summary" className="flex-1 min-h-0 overflow-hidden">
+          <div className="grid h-full min-h-0 gap-5 overflow-y-auto pr-3 custom-scrollbar xl:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="space-y-4">
+              <section className="rounded-xl border border-border bg-card p-4 shadow-sm">
+                <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Pace of Speech
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground">{pacingMessage}</p>
+                  </div>
+                  <p className="text-2xl font-semibold text-foreground sm:text-right">
+                    {analytics.pacing.wordsPerMinute}
+                    <span className="ml-1 text-sm font-normal text-muted-foreground">words/min</span>
+                  </p>
+                </div>
+                <PacingVariationChart
+                  wpm={analytics.pacing.wordsPerMinute}
+                  segments={analytics.pacing.segments}
+                  durationSeconds={analytics.pacing.durationSeconds}
+                />
+              </section>
+
+              <div className="grid auto-rows-fr gap-4 md:grid-cols-5">
+              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-2">
+                <div className="flex items-center justify-between border-b border-border/70 pb-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Filler Words
+                  </p>
+                  <span className="text-xs text-muted-foreground">
+                    {analytics.fillerWords.count} total
+                  </span>
+                </div>
+                <p className="mt-4 text-3xl font-semibold text-foreground">
+                  {analytics.fillerWords.ratePerMinute.toFixed(1)}
+                  <span className="ml-1 text-sm font-normal text-muted-foreground">words/min</span>
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  You may be repeating filler words several times.
+                </p>
+                {analytics.fillerWords.instances.length > 0 && (
+                  <div className="mt-4 flex flex-wrap gap-1.5">
+                    {analytics.fillerWords.instances.slice(0, 6).map((instance, idx) => {
+                      const wordData = wordTimestampMap.get(instance.position);
+                      if (!wordData) {
+                        return (
+                          <span
+                            key={`${instance.word}-${idx}`}
+                            className="rounded-md border border-yellow-500/20 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-700 dark:text-yellow-400"
+                          >
+                            {instance.word}
+                          </span>
+                        );
+                      }
+
+                      return (
+                        <button
+                          key={`${instance.word}-${idx}`}
+                          onClick={() => handleSeekToTime(wordData.startTime, wordData.wordId)}
+                          className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-yellow-500/20 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-700 transition-colors hover:bg-yellow-500/20 dark:text-yellow-400"
+                          title={`Jump to "${instance.word}" at ${formatTimestamp(wordData.startTime)}`}
+                        >
+                          <Play className="h-2.5 w-2.5" fill="currentColor" />
+                          {instance.word}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+
+              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-3">
+                <div className="flex items-center justify-between border-b border-border/70 pb-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Repetition
+                  </p>
+                  <span className="text-xs text-muted-foreground">Repeated words</span>
+                </div>
+                <p className="mt-4 text-3xl font-semibold text-foreground">
+                  {repeatedWordCount}
+                  <span className="ml-1 text-sm font-normal text-muted-foreground">instances</span>
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Repeated words can make speech feel less concise.
+                </p>
+                <div className="mt-4 space-y-2">
+                  {analytics.repetitions.repeatedWords.length > 0 ? (
+                    analytics.repetitions.repeatedWords.slice(0, 4).map((item) => (
+                      <div key={item.word} className="flex items-center justify-between text-sm">
+                        <span className="capitalize text-muted-foreground">{item.word}</span>
+                        <span className="font-medium text-foreground">{item.count}x</span>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No excessive repetitions detected.</p>
+                  )}
+                </div>
+              </section>
+
+              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-3">
+                <div className="flex items-center justify-between border-b border-border/70 pb-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Weak Words
+                  </p>
+                  <span className="text-xs text-muted-foreground">Word choice</span>
+                </div>
+                <p className="mt-4 text-3xl font-semibold text-foreground">
+                  {analytics.weakWords.length}
+                  <span className="ml-1 text-sm font-normal text-muted-foreground">found</span>
+                </p>
+                <div className="mt-4 space-y-3">
+                  {analytics.weakWords.length > 0 ? (
+                    analytics.weakWords.slice(0, 2).map((item, index) => (
+                      <div key={index} className="rounded-lg bg-muted/35 p-3">
+                        <p className="text-xs text-muted-foreground">
+                          Weak word: <span className="font-medium text-foreground">"{item.word}"</span>
+                        </p>
+                        <p className="mt-1 line-clamp-2 text-xs italic text-foreground/80">
+                          "{item.sentence}"
+                        </p>
+                        {item.suggestion && (
+                          <p className="mt-2 text-xs font-medium text-primary">
+                            -&gt; "{item.suggestion}"
+                          </p>
+                        )}
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No weak words detected.</p>
+                  )}
+                  {analytics.weakWords.some((word) => !word.suggestion) && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleGenerateSuggestions}
+                      disabled={isGeneratingSuggestions}
+                      className="h-8 w-full text-xs"
+                    >
+                      {isGeneratingSuggestions ? (
+                        <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                      ) : (
+                        <Sparkles className="mr-1 h-3 w-3" />
+                      )}
+                      Generate AI Suggestions
+                    </Button>
+                  )}
+                </div>
+              </section>
+
+              <section className="flex h-full flex-col rounded-xl border border-border bg-card p-5 shadow-sm md:col-span-2">
+                <div className="flex items-center justify-between border-b border-border/70 pb-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Sentence Starters
+                  </p>
+                  <span className="text-xs text-muted-foreground">Flow</span>
+                </div>
+                <p className="mt-4 text-3xl font-semibold text-foreground">
+                  {sentenceStarterTotal}
+                  <span className="ml-1 text-sm font-normal text-muted-foreground">uses</span>
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {topSentenceStarter
+                    ? `"${topSentenceStarter.word}" showed up most often.`
+                    : "No weak sentence starters detected."}
+                </p>
+                <div className="mt-4 space-y-2">
+                  {analytics.sentenceStarters.weak.slice(0, 4).map((item) => (
+                    <div key={item.word} className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">"{item.word}"</span>
+                      <span className="font-medium text-foreground">{item.count}x</span>
+                    </div>
+                  ))}
+                </div>
+              </section>
+              </div>
+            </div>
+
+            <aside className="rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm xl:sticky xl:top-0 xl:self-start">
+              <div className="mb-4 border-b border-primary/20 pb-3">
+                <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Focus areas from this conversation.
+                </p>
+              </div>
+              {currentUser ? (
+                <PersonalizedFeedback
+                  conversationId={conversationId}
+                  userId={currentUser._id}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">Sign in to view personalized insights.</p>
+              )}
+            </aside>
+          </div>
+        </TabsContent>
 
         {/* Overview Tab - AI Feedback */}
         <TabsContent value="overview" className="flex-1 min-h-0 overflow-hidden">

--- a/apps/web/app/components/dashboard/app-sidebar.tsx
+++ b/apps/web/app/components/dashboard/app-sidebar.tsx
@@ -1,16 +1,24 @@
-import { IconDashboard, IconSettings, IconMessageCircle, IconMessages, IconChartBar, IconUsers } from "@tabler/icons-react";
-import { Link } from "react-router";
-import { NavMain } from "./nav-main";
-import { NavSecondary } from "./nav-secondary";
-import { NavUser } from "./nav-user";
+import { api } from "@audora/backend/convex/_generated/api";
+import { IconChartBar, IconMessageCircle, IconMessages, IconSettings, IconUsers } from "@tabler/icons-react";
+import { useQuery } from "convex/react";
+import { Link, useLocation } from "react-router";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
 } from "~/components/ui/sidebar";
+import { NavMain } from "./nav-main";
+import { NavSecondary } from "./nav-secondary";
+import { NavUser } from "./nav-user";
 
 const data = {
   navMain: [
@@ -51,6 +59,11 @@ export function AppSidebar({
   variant: "sidebar" | "floating" | "inset";
   user: any;
 }) {
+  const location = useLocation();
+  const isChatPage = location.pathname === "/dashboard/chat";
+  const activeThreadKey = new URLSearchParams(location.search).get("thread") ?? "general";
+  const chatThreads = useQuery(api.chat.listThreads, isChatPage ? {} : "skip");
+
   return (
     <Sidebar collapsible="icon" variant={variant}>
       <SidebarHeader>
@@ -69,6 +82,28 @@ export function AppSidebar({
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={data.navMain} />
+        {isChatPage && chatThreads && chatThreads.length > 0 ? (
+          <SidebarGroup className="pt-0">
+            <SidebarGroupLabel>Chat History</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenuSub>
+                {chatThreads.map((thread) => (
+                  <SidebarMenuSubItem key={thread.threadKey}>
+                    <SidebarMenuSubButton asChild isActive={activeThreadKey === thread.threadKey}>
+                      <Link
+                        to={thread.threadKey === "general" ? "/dashboard/chat" : `/dashboard/chat?thread=${encodeURIComponent(thread.threadKey)}`}
+                        prefetch="intent"
+                        title={thread.preview}
+                      >
+                        <span>{thread.title}</span>
+                      </Link>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                ))}
+              </SidebarMenuSub>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null}
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>{user && <NavUser user={user} />}</SidebarFooter>

--- a/apps/web/app/components/dashboard/app-sidebar.tsx
+++ b/apps/web/app/components/dashboard/app-sidebar.tsx
@@ -52,12 +52,17 @@ export function AppSidebar({
   user: any;
 }) {
   return (
-    <Sidebar collapsible="offcanvas" variant={variant}>
+    <Sidebar collapsible="icon" variant={variant}>
       <SidebarHeader>
         <SidebarMenu>
-          <SidebarMenuItem>
-            <Link to="/" prefetch="viewport">
-              <span className="text-base font-semibold">Audora</span>
+          <SidebarMenuItem className="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
+            <Link
+              to="/"
+              prefetch="viewport"
+              className="block group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:size-10 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center"
+            >
+              <span className="text-base font-semibold group-data-[collapsible=icon]:hidden">Audora</span>
+              <span className="hidden text-xl font-bold leading-none group-data-[collapsible=icon]:block">A</span>
             </Link>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/apps/web/app/components/dashboard/nav-main.tsx
+++ b/apps/web/app/components/dashboard/nav-main.tsx
@@ -40,7 +40,11 @@ export const NavMain = memo(({
                 isActive={item.isActive}
                 asChild
               >
-                <Link to={item.url} prefetch="intent">
+                <Link
+                  to={item.url}
+                  prefetch="intent"
+                  className="group-data-[collapsible=icon]:justify-center"
+                >
                   {item.icon && <item.icon />}
                   <span>{item.title}</span>
                 </Link>

--- a/apps/web/app/components/dashboard/nav-secondary.tsx
+++ b/apps/web/app/components/dashboard/nav-secondary.tsx
@@ -36,14 +36,18 @@ export function NavSecondary({
             return (
               <SidebarMenuItem key={item.title}>
                 {isImplemented ? (
-                  <SidebarMenuButton isActive={isActive} asChild>
-                    <Link to={item.url} prefetch="intent">
+                  <SidebarMenuButton tooltip={item.title} isActive={isActive} asChild>
+                    <Link
+                      to={item.url}
+                      prefetch="intent"
+                      className="group-data-[collapsible=icon]:justify-center"
+                    >
                       <item.icon />
                       <span>{item.title}</span>
                     </Link>
                   </SidebarMenuButton>
                 ) : (
-                  <SidebarMenuButton disabled>
+                  <SidebarMenuButton tooltip={item.title} disabled>
                     <item.icon />
                     <span>{item.title}</span>
                   </SidebarMenuButton>

--- a/apps/web/app/components/dashboard/nav-user.tsx
+++ b/apps/web/app/components/dashboard/nav-user.tsx
@@ -40,7 +40,7 @@ export function NavUser({ user }: any) {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-0!"
             >
               <Avatar className="h-8 w-8 rounded-lg">
                 <AvatarImage src={userProfile} alt={userFullName} />
@@ -48,13 +48,13 @@ export function NavUser({ user }: any) {
                   {userInitials}
                 </AvatarFallback>
               </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight">
+              <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
                 <span className="truncate font-medium">{userFullName}</span>
                 <span className="text-muted-foreground truncate text-xs">
                   {userEmail}
                 </span>
               </div>
-              <IconDotsVertical className="ml-auto size-4" />
+              <IconDotsVertical className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/apps/web/app/components/dashboard/site-header.tsx
+++ b/apps/web/app/components/dashboard/site-header.tsx
@@ -1,7 +1,5 @@
-import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
 import { SidebarTrigger } from "~/components/ui/sidebar";
-import { ThemeToggle } from "../ThemeToggle";
 
 export function SiteHeader() {
   return (
@@ -23,7 +21,6 @@ export function SiteHeader() {
               GitHub
             </a>
           </Button> */}
-          <ThemeToggle />
         </div>
       </div>
     </header>

--- a/apps/web/app/components/ui/sidebar.tsx
+++ b/apps/web/app/components/ui/sidebar.tsx
@@ -93,6 +93,17 @@ function SidebarProvider({
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
+  const wasMobileRef = React.useRef(isMobile)
+
+  React.useEffect(() => {
+    if (wasMobileRef.current && !isMobile) {
+      setOpen(false)
+      setOpenMobile(false)
+    }
+
+    wasMobileRef.current = isMobile
+  }, [isMobile, setOpen, setOpenMobile])
+
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -474,7 +485,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 group-data-[collapsible=icon]:[&>svg]:size-5 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/apps/web/app/routes/dashboard/chat.tsx
+++ b/apps/web/app/routes/dashboard/chat.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { api } from "@audora/backend/convex/_generated/api";
+import type { Id } from "@audora/backend/convex/_generated/dataModel";
 import { useAuth, useUser } from "@clerk/react-router";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import {
   FolderOpen,
   Loader2,
@@ -13,6 +14,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
+import { useSearchParams } from "react-router";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -39,6 +41,8 @@ const SUGGESTED_PROMPTS = [
   "Help me prepare for my pitch",
 ];
 
+const GENERAL_THREAD_KEY = "general";
+
 interface Message {
   id: string;
   role: "user" | "assistant";
@@ -57,19 +61,57 @@ interface ChatConversation {
   participantCount: number;
 }
 
+function buildChatThreadKey(conversationIds: string[]) {
+  if (conversationIds.length === 0) {
+    return GENERAL_THREAD_KEY;
+  }
+
+  const sortedIds = [...conversationIds].sort();
+
+  if (sortedIds.length === 1) {
+    return `conversation:${sortedIds[0]}`;
+  }
+
+  return `multi:${sortedIds.join("|")}`;
+}
+
+function parseChatThreadKey(threadKey: string) {
+  if (!threadKey || threadKey === GENERAL_THREAD_KEY) {
+    return [];
+  }
+
+  if (threadKey.startsWith("conversation:")) {
+    const conversationId = threadKey.slice("conversation:".length);
+    return conversationId ? [conversationId] : [];
+  }
+
+  if (threadKey.startsWith("multi:")) {
+    return threadKey
+      .slice("multi:".length)
+      .split("|")
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
 export default function Chat() {
   const { isSignedIn, getToken } = useAuth();
   const { user } = useUser();
+  const [searchParams, setSearchParams] = useSearchParams();
   const conversations = (useQuery(api.conversations.list) ?? []) as ChatConversation[];
+  const saveMessage = useMutation(api.chat.saveMessage);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
-  const [selectedConversationIds, setSelectedConversationIds] = useState<string[]>([]);
   const [draftSelectedConversationIds, setDraftSelectedConversationIds] = useState<string[]>([]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const activeThreadKey = searchParams.get("thread") ?? GENERAL_THREAD_KEY;
+  const selectedConversationIds = parseChatThreadKey(activeThreadKey);
+  const chatHistory = useQuery(api.chat.getMessages, { threadKey: activeThreadKey });
 
   const firstName =
     user?.firstName ||
@@ -85,6 +127,37 @@ export default function Chat() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  useEffect(() => {
+    setMessages([]);
+  }, [activeThreadKey]);
+
+  useEffect(() => {
+    if (chatHistory === undefined || isLoading) {
+      return;
+    }
+
+    setMessages(
+      chatHistory.map((message) => ({
+        id: message._id,
+        role: message.role as "user" | "assistant",
+        content: message.content,
+      }))
+    );
+  }, [chatHistory, isLoading]);
+
+  const setActiveThread = (threadKey: string) => {
+    const normalizedThreadKey = threadKey || GENERAL_THREAD_KEY;
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (normalizedThreadKey === GENERAL_THREAD_KEY) {
+      nextParams.delete("thread");
+    } else {
+      nextParams.set("thread", normalizedThreadKey);
+    }
+
+    setSearchParams(nextParams);
+  };
+
   const openConversationPicker = () => {
     setDraftSelectedConversationIds(selectedConversationIds);
     setIsPickerOpen(true);
@@ -99,12 +172,12 @@ export default function Chat() {
   };
 
   const applyConversationSelection = () => {
-    setSelectedConversationIds(draftSelectedConversationIds);
+    setActiveThread(buildChatThreadKey(draftSelectedConversationIds));
     setIsPickerOpen(false);
   };
 
   const removeLinkedConversation = (conversationId: string) => {
-    setSelectedConversationIds((current) => current.filter((id) => id !== conversationId));
+    setActiveThread(buildChatThreadKey(selectedConversationIds.filter((id) => id !== conversationId)));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -123,8 +196,28 @@ export default function Chat() {
     }));
 
     setMessages((prev) => [...prev, userMessage]);
+    const userInput = input;
     setInput("");
     setIsLoading(true);
+
+    const singleConversationId =
+      selectedConversationIds.length === 1
+        ? (selectedConversationIds[0] as Id<"conversations">)
+        : undefined;
+    const linkedConversationIds =
+      selectedConversationIds.length > 1
+        ? (selectedConversationIds as Id<"conversations">[])
+        : undefined;
+
+    saveMessage({
+      conversationId: singleConversationId,
+      linkedConversationIds,
+      threadKey: activeThreadKey,
+      role: "user",
+      content: userInput,
+    }).catch((error) => {
+      console.error("Failed to save user message:", error);
+    });
 
     const assistantMessageId = `assistant-${Date.now()}`;
     setMessages((prev) => [
@@ -176,6 +269,18 @@ export default function Chat() {
               : message
           )
         );
+      }
+
+      if (assistantContent) {
+        saveMessage({
+          conversationId: singleConversationId,
+          linkedConversationIds,
+          threadKey: activeThreadKey,
+          role: "assistant",
+          content: assistantContent,
+        }).catch((error) => {
+          console.error("Failed to save assistant message:", error);
+        });
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";

--- a/apps/web/app/routes/dashboard/chat.tsx
+++ b/apps/web/app/routes/dashboard/chat.tsx
@@ -1,190 +1,649 @@
 "use client";
 
-import { useChat } from "@ai-sdk/react";
+import { api } from "@audora/backend/convex/_generated/api";
+import { useAuth, useUser } from "@clerk/react-router";
+import { useQuery } from "convex/react";
+import {
+  FolderOpen,
+  Loader2,
+  Mic,
+  Send,
+  Sparkles,
+  X,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
+import { getConversationDisplayTitle } from "~/lib/conversation-context";
 import { cn } from "~/lib/utils";
-import { Send, Loader2, Sparkles } from "lucide-react";
-import { useEffect, useRef } from "react";
 
 const CONVEX_SITE_URL = import.meta.env.VITE_CONVEX_URL!.replace(
   /.cloud$/,
   ".site"
 );
 
+const SUGGESTED_PROMPTS = [
+  "Analyze my tone this week",
+  "Weak areas I should focus on?",
+  "Help me prepare for my pitch",
+];
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface ChatConversation {
+  _id: string;
+  _creationTime: number;
+  status: "pending" | "active" | "ended";
+  participants: Array<{
+    _id: string;
+    name?: string;
+    image?: string;
+  }>;
+  participantCount: number;
+}
+
 export default function Chat() {
-  const { messages, input, handleInputChange, handleSubmit, isLoading } =
-    useChat({
-      maxSteps: 10,
-      api: `${CONVEX_SITE_URL}/api/chat`,
-    });
+  const { isSignedIn, getToken } = useAuth();
+  const { user } = useUser();
+  const conversations = (useQuery(api.conversations.list) ?? []) as ChatConversation[];
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [selectedConversationIds, setSelectedConversationIds] = useState<string[]>([]);
+  const [draftSelectedConversationIds, setDraftSelectedConversationIds] = useState<string[]>([]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
+  const firstName =
+    user?.firstName ||
+    user?.fullName?.split(" ")[0] ||
+    user?.primaryEmailAddress?.emailAddress?.split("@")[0] ||
+    "there";
+
+  const linkedConversations = conversations.filter((conversation) =>
+    selectedConversationIds.includes(conversation._id)
+  );
 
   useEffect(() => {
-    scrollToBottom();
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  const openConversationPicker = () => {
+    setDraftSelectedConversationIds(selectedConversationIds);
+    setIsPickerOpen(true);
+  };
+
+  const toggleDraftConversation = (conversationId: string) => {
+    setDraftSelectedConversationIds((current) =>
+      current.includes(conversationId)
+        ? current.filter((id) => id !== conversationId)
+        : [...current, conversationId]
+    );
+  };
+
+  const applyConversationSelection = () => {
+    setSelectedConversationIds(draftSelectedConversationIds);
+    setIsPickerOpen(false);
+  };
+
+  const removeLinkedConversation = (conversationId: string) => {
+    setSelectedConversationIds((current) => current.filter((id) => id !== conversationId));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || isLoading || !isSignedIn) return;
+
+    const userMessage: Message = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content: input,
+    };
+
+    const apiMessages = [...messages, userMessage].map((message) => ({
+      role: message.role,
+      content: message.content,
+    }));
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setIsLoading(true);
+
+    const assistantMessageId = `assistant-${Date.now()}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: assistantMessageId, role: "assistant", content: "" },
+    ]);
+
+    try {
+      const token = await getToken({ template: "convex" });
+
+      if (!token) {
+        throw new Error("Missing Convex auth token");
+      }
+
+      const response = await fetch(`${CONVEX_SITE_URL}/api/chat`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        credentials: "include",
+        body: JSON.stringify({
+          messages: apiMessages,
+          conversationIds: selectedConversationIds,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("Response body is empty");
+      }
+
+      const decoder = new TextDecoder();
+      let assistantContent = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        assistantContent += decoder.decode(value, { stream: true });
+        setMessages((prev) =>
+          prev.map((message) =>
+            message.id === assistantMessageId
+              ? { ...message, content: assistantContent }
+              : message
+          )
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setMessages((prev) =>
+        prev.map((chatMessage) =>
+          chatMessage.id === assistantMessageId
+            ? {
+                ...chatMessage,
+                content: `Sorry, the coach request failed. ${message}`,
+              }
+            : chatMessage
+        )
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const linkedButtonLabel =
+    selectedConversationIds.length > 0
+      ? `${selectedConversationIds.length} conversation${selectedConversationIds.length === 1 ? "" : "s"} linked`
+      : "Connect past conversations";
+
   return (
-    <div className="flex flex-col h-[calc(100vh-4rem)] w-full">
-      {/* Header */}
-      <div className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-10">
-        <div className="max-w-4xl mx-auto px-4 py-4">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-primary/10">
-              <Sparkles className="w-5 h-5 text-primary" />
-            </div>
-            <div>
-              <h1 className="text-lg font-semibold text-foreground">Communication Coach</h1>
-              <p className="text-xs text-muted-foreground">Your Personal Reflection & Relationship Expert</p>
+    <>
+      <div className="flex h-[calc(100vh-4rem)] w-full flex-col overflow-hidden bg-background">
+        {messages.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8 sm:px-6">
+            <div className="w-full max-w-3xl space-y-8">
+              <div className="flex flex-col items-center gap-5 text-center">
+                <div className="inline-flex items-center gap-4 rounded-full px-5 py-3">
+                  <AudoraMark />
+                  <span className="text-4xl font-semibold tracking-tight text-foreground">
+                    Audora
+                  </span>
+                </div>
+              </div>
+
+              <section className="mx-auto max-w-2xl space-y-4">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                  <div className="space-y-1 text-left">
+                    <p className="text-2xl text-muted-foreground">Hi {firstName}</p>
+                    <h1 className="text-[2rem] font-medium tracking-tight text-foreground sm:text-[2.25rem]">
+                      What&apos;s on your mind today?
+                    </h1>
+                  </div>
+
+                  <Button
+                    type="button"
+                    onClick={openConversationPicker}
+                    className="h-11 self-start rounded-xl sm:self-auto"
+                  >
+                    <FolderOpen className="size-4" />
+                    {linkedButtonLabel}
+                  </Button>
+                </div>
+
+                <CoachComposer
+                  compact={false}
+                  conversations={linkedConversations}
+                  input={input}
+                  inputRef={inputRef}
+                  isLoading={isLoading}
+                  onChange={setInput}
+                  onOpenConversationPicker={openConversationPicker}
+                  onPromptClick={(prompt) => {
+                    setInput(prompt);
+                    inputRef.current?.focus();
+                  }}
+                  onRemoveConversation={removeLinkedConversation}
+                  onSubmit={handleSubmit}
+                  pickerButtonLabel={linkedButtonLabel}
+                />
+              </section>
             </div>
           </div>
-        </div>
-      </div>
-
-      {/* Messages Container */}
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-4xl mx-auto px-4 py-6">
-          {messages.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full text-center py-12">
-              <div className="p-4 rounded-full bg-primary/10 mb-4">
-                <Sparkles className="w-8 h-8 text-primary" />
+        ) : (
+          <>
+            <div className="border-b border-border bg-card/50 backdrop-blur-sm">
+              <div className="mx-auto flex w-full max-w-5xl items-center gap-3 px-4 py-4 sm:px-6">
+                <AudoraMark compact />
+                <div>
+                  <h1 className="text-lg font-semibold text-foreground">Audora</h1>
+                  <p className="text-sm text-muted-foreground">Communication coach</p>
+                </div>
               </div>
-              <h2 className="text-xl font-semibold text-foreground mb-2">Let's Reflect Together</h2>
-              <p className="text-muted-foreground max-w-md mb-4">
-                I'm your communication coach and reflection expert. I have access to all your conversations and can help you:
-              </p>
-              <ul className="text-muted-foreground text-sm space-y-2 max-w-md text-left">
-                <li className="flex items-start gap-2">
-                  <span className="text-primary mt-0.5">✓</span>
-                  <span>Analyze your communication patterns and style</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-primary mt-0.5">✓</span>
-                  <span>Reflect on specific conversations and what you learned</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-primary mt-0.5">✓</span>
-                  <span>Discover insights about your relationships</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-primary mt-0.5">✓</span>
-                  <span>Get personalized coaching to improve your connections</span>
-                </li>
-              </ul>
-              <p className="text-muted-foreground text-sm max-w-md mt-4">
-                Ask me anything about your conversations or how to connect better with others.
-              </p>
             </div>
-          ) : (
-            <div className="space-y-6">
-              {messages.map((message, i) => (
-                <div
-                  key={message.id}
-                  className={cn(
-                    "flex gap-3",
-                    message.role === "user" ? "justify-end" : "justify-start"
-                  )}
-                >
-                  {message.role === "assistant" && (
-                    <div className="flex-shrink-0">
-                      <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
-                        <Sparkles className="w-4 h-4 text-primary" />
+
+            <div className="flex-1 overflow-y-auto px-4 py-6 sm:px-6">
+              <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+                {linkedConversations.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {linkedConversations.map((conversation) => (
+                      <LinkedConversationChip
+                        key={conversation._id}
+                        conversation={conversation}
+                        onRemove={() => removeLinkedConversation(conversation._id)}
+                      />
+                    ))}
+                  </div>
+                ) : null}
+
+                <div className="space-y-6">
+                  {messages.map((message) => (
+                    <div
+                      key={message.id}
+                      className={cn(
+                        "flex gap-3",
+                        message.role === "user" ? "justify-end" : "justify-start"
+                      )}
+                    >
+                      {message.role === "assistant" ? (
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
+                          <Sparkles className="size-5" />
+                        </div>
+                      ) : null}
+
+                      <div
+                        className={cn(
+                          "max-w-[85%] rounded-3xl px-5 py-4 shadow-sm sm:max-w-[70%]",
+                          message.role === "user"
+                            ? "bg-primary text-primary-foreground"
+                            : "border border-border bg-card text-foreground"
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            "prose prose-sm max-w-none",
+                            message.role === "user"
+                              ? "prose-invert"
+                              : "prose-foreground dark:prose-invert",
+                            "prose-p:my-1 prose-li:my-0.5 prose-ul:my-2 prose-ol:my-2",
+                            "prose-headings:mt-3 prose-headings:mb-2"
+                          )}
+                        >
+                          <Markdown>{message.content}</Markdown>
+                        </div>
                       </div>
                     </div>
-                  )}
-                  <div
+                  ))}
+
+                  {isLoading ? (
+                    <div className="flex gap-3 justify-start">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
+                        <Sparkles className="size-5" />
+                      </div>
+                      <div className="rounded-3xl border border-border bg-card px-5 py-4 shadow-sm">
+                        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div ref={messagesEndRef} />
+                </div>
+              </div>
+            </div>
+
+            <div className="border-t border-border bg-card/50 px-4 py-4 backdrop-blur-sm sm:px-6">
+              <div className="mx-auto w-full max-w-5xl">
+                <CoachComposer
+                  compact
+                  conversations={linkedConversations}
+                  input={input}
+                  inputRef={inputRef}
+                  isLoading={isLoading}
+                  onChange={setInput}
+                  onOpenConversationPicker={openConversationPicker}
+                  onRemoveConversation={removeLinkedConversation}
+                  onSubmit={handleSubmit}
+                  pickerButtonLabel={linkedButtonLabel}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <Dialog open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+        <DialogContent className="max-w-2xl border-border bg-card p-0">
+          <DialogHeader className="border-b border-border px-6 py-5">
+            <DialogTitle className="text-foreground">Connect past conversations</DialogTitle>
+            <DialogDescription>
+              Link specific conversations so Audora can focus the coaching on those exchanges.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-[55vh] space-y-3 overflow-y-auto px-6 py-5">
+            {conversations.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+                No conversations available to link yet.
+              </div>
+            ) : (
+              conversations.map((conversation) => {
+                const checked = draftSelectedConversationIds.includes(conversation._id);
+
+                return (
+                  <label
+                    key={conversation._id}
                     className={cn(
-                      "max-w-[75%] px-4 py-3 rounded-2xl shadow-sm",
-                      message.role === "user"
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-card border border-border"
+                      "flex cursor-pointer items-start gap-4 rounded-2xl border px-4 py-4 transition-colors",
+                      checked
+                        ? "border-primary bg-primary/5"
+                        : "border-border bg-card hover:border-primary/40 hover:bg-muted/30"
                     )}
                   >
-                    {message.parts.map((part) => {
-                      switch (part.type) {
-                        case "text":
-                          return (
-                            <div
-                              key={`${message.id}-${i}`}
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={() => toggleDraftConversation(conversation._id)}
+                      className="mt-1"
+                    />
+                    <div className="min-w-0 flex-1 space-y-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-foreground">
+                          {getConversationDisplayTitle(conversation)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatConversationDate(conversation._creationTime)}
+                        </p>
+                      </div>
+
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center">
+                          {conversation.participants.slice(0, 3).map((participant, index) => (
+                            <Avatar
+                              key={participant._id}
                               className={cn(
-                                "prose prose-sm max-w-none",
-                                message.role === "user"
-                                  ? "prose-invert"
-                                  : "prose-foreground",
-                                "prose-p:my-1 prose-li:my-0.5 prose-ul:my-2 prose-ol:my-2",
-                                "prose-headings:mt-3 prose-headings:mb-2",
-                                "prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded"
+                                "size-8 border-2 border-card bg-muted shadow-sm",
+                                index === 0 ? "" : "-ml-2"
                               )}
                             >
-                              <Markdown>{part.text}</Markdown>
+                              <AvatarImage src={participant.image} alt={participant.name ?? "Participant"} />
+                              <AvatarFallback className="text-[10px] font-medium text-foreground">
+                                {getParticipantInitials(participant.name)}
+                              </AvatarFallback>
+                            </Avatar>
+                          ))}
+                          {conversation.participantCount > 3 ? (
+                            <div className="-ml-2 flex size-8 items-center justify-center rounded-full border-2 border-card bg-muted text-[11px] font-semibold text-muted-foreground shadow-sm">
+                              +{conversation.participantCount - 3}
                             </div>
-                          );
-                        default:
-                          return null;
-                      }
-                    })}
-                  </div>
-                  {message.role === "user" && (
-                    <div className="flex-shrink-0">
-                      <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-sm font-medium">
-                        U
+                          ) : null}
+                        </div>
+
+                        <span className="text-xs text-muted-foreground">
+                          {conversation.status === "ended" ? "Completed" : "In progress"}
+                        </span>
                       </div>
                     </div>
-                  )}
-                </div>
-              ))}
-              {isLoading && (
-                <div className="flex gap-3 justify-start">
-                  <div className="flex-shrink-0">
-                    <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
-                      <Sparkles className="w-4 h-4 text-primary" />
-                    </div>
-                  </div>
-                  <div className="bg-card border border-border px-4 py-3 rounded-2xl">
-                    <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
-                  </div>
-                </div>
-              )}
-              <div ref={messagesEndRef} />
-            </div>
-          )}
+                  </label>
+                );
+              })
+            )}
+          </div>
+
+          <DialogFooter className="border-t border-border px-6 py-4">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setDraftSelectedConversationIds([])}
+            >
+              Clear all
+            </Button>
+            <Button type="button" onClick={applyConversationSelection}>
+              Link {draftSelectedConversationIds.length > 0 ? `${draftSelectedConversationIds.length} conversation${draftSelectedConversationIds.length === 1 ? "" : "s"}` : "conversations"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function CoachComposer({
+  compact = false,
+  conversations,
+  input,
+  inputRef,
+  isLoading,
+  onChange,
+  onOpenConversationPicker,
+  onPromptClick,
+  onRemoveConversation,
+  onSubmit,
+  pickerButtonLabel,
+}: {
+  compact?: boolean;
+  conversations: ChatConversation[];
+  input: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  isLoading: boolean;
+  onChange: (value: string) => void;
+  onOpenConversationPicker: () => void;
+  onPromptClick?: (value: string) => void;
+  onRemoveConversation: (conversationId: string) => void;
+  onSubmit: (e: React.FormEvent) => Promise<void> | void;
+  pickerButtonLabel: string;
+}) {
+  return (
+    <div className="space-y-3">
+      {compact ? (
+        <div className="flex items-center justify-end">
+          <Button
+            type="button"
+            onClick={onOpenConversationPicker}
+            className="h-11 rounded-xl"
+          >
+            <FolderOpen className="size-4" />
+            {pickerButtonLabel}
+          </Button>
         </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-border bg-card p-3 shadow-sm">
+        {conversations.length > 0 ? (
+          <div className="mb-3 flex flex-wrap gap-2 border-b border-border pb-3">
+            {conversations.map((conversation) => (
+              <LinkedConversationChip
+                key={conversation._id}
+                conversation={conversation}
+                onRemove={() => onRemoveConversation(conversation._id)}
+              />
+            ))}
+          </div>
+        ) : null}
+
+        <form onSubmit={onSubmit} className="flex items-center gap-2">
+          <Input
+            ref={inputRef}
+            value={input}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="Ask Audora"
+            disabled={isLoading}
+            className="h-12 border-0 bg-transparent px-3 text-base text-foreground shadow-none focus-visible:ring-0"
+          />
+          <button
+            type="button"
+            disabled
+            className="flex size-10 items-center justify-center rounded-full text-muted-foreground opacity-70"
+            aria-label="Voice input coming soon"
+          >
+            <Mic className="size-5" />
+          </button>
+          <Button
+            type="submit"
+            size="icon"
+            disabled={isLoading || !input.trim()}
+            className="size-10 rounded-full"
+          >
+            {isLoading ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+          </Button>
+        </form>
       </div>
 
-      {/* Input Form */}
-      <div className="border-t border-border bg-card/50 backdrop-blur-sm sticky bottom-0">
-        <div className="max-w-4xl mx-auto px-4 py-4">
-          <form onSubmit={handleSubmit} className="flex gap-2">
-            <div className="flex-1 relative">
-              <Input
-                className="w-full pr-12 bg-background border-border focus:border-primary"
-                value={input}
-                placeholder="Type your message..."
-                onChange={handleInputChange}
-                disabled={isLoading}
-              />
-            </div>
-            <Button 
-              type="submit" 
-              size="icon"
-              disabled={isLoading || !input.trim()}
-              className="flex-shrink-0"
+      {!compact && onPromptClick ? (
+        <div className="flex flex-wrap gap-3">
+          {SUGGESTED_PROMPTS.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              onClick={() => onPromptClick(prompt)}
+              className="rounded-full border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
             >
-              {isLoading ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <Send className="w-4 h-4" />
-              )}
-            </Button>
-          </form>
+              {prompt}
+            </button>
+          ))}
         </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LinkedConversationChip({
+  conversation,
+  onRemove,
+}: {
+  conversation: ChatConversation;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="inline-flex max-w-full items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-2 text-sm text-foreground">
+      <div className="flex items-center">
+        {conversation.participants.slice(0, 2).map((participant, index) => (
+          <Avatar
+            key={participant._id}
+            className={cn(
+              "size-6 border border-card bg-muted",
+              index === 0 ? "" : "-ml-1.5"
+            )}
+          >
+            <AvatarImage src={participant.image} alt={participant.name ?? "Participant"} />
+            <AvatarFallback className="text-[9px] font-medium text-foreground">
+              {getParticipantInitials(participant.name)}
+            </AvatarFallback>
+          </Avatar>
+        ))}
+      </div>
+      <span className="truncate">{formatConversationDate(conversation._creationTime)}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+        aria-label="Remove linked conversation"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function AudoraMark({ compact = false }: { compact?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "grid place-items-end rounded-2xl bg-primary/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]",
+        compact ? "size-11 p-2" : "size-14 p-2.5"
+      )}
+    >
+      <div className="flex h-full w-full items-end gap-1">
+        {[0.4, 0.7, 1, 0.8, 0.55].map((height, index) => (
+          <span
+            key={index}
+            className="flex-1 rounded-full bg-primary"
+            style={{ height: `${height * 100}%` }}
+          />
+        ))}
       </div>
     </div>
   );
+}
+
+function formatConversationDate(timestamp: number) {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return `Today, ${date.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    })}`;
+  }
+
+  if (diffDays === 1) {
+    return `Yesterday, ${date.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    })}`;
+  }
+
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function getParticipantInitials(name?: string) {
+  if (!name) {
+    return "?";
+  }
+
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return "?";
+  }
+
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
 }

--- a/apps/web/app/routes/dashboard/chat.tsx
+++ b/apps/web/app/routes/dashboard/chat.tsx
@@ -215,22 +215,11 @@ export default function Chat() {
               </div>
 
               <section className="mx-auto max-w-2xl space-y-4">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                  <div className="space-y-1 text-left">
-                    <p className="text-2xl text-muted-foreground">Hi {firstName}</p>
-                    <h1 className="text-[2rem] font-medium tracking-tight text-foreground sm:text-[2.25rem]">
-                      What&apos;s on your mind today?
-                    </h1>
-                  </div>
-
-                  <Button
-                    type="button"
-                    onClick={openConversationPicker}
-                    className="h-11 self-start rounded-xl sm:self-auto"
-                  >
-                    <FolderOpen className="size-4" />
-                    {linkedButtonLabel}
-                  </Button>
+                <div className="space-y-1 text-left">
+                  <p className="text-2xl text-muted-foreground">Hi {firstName}</p>
+                  <h1 className="text-[2rem] font-medium tracking-tight text-foreground sm:text-[2.25rem]">
+                    What&apos;s on your mind today?
+                  </h1>
                 </div>
 
                 <CoachComposer
@@ -266,18 +255,6 @@ export default function Chat() {
 
             <div className="flex-1 overflow-y-auto px-4 py-6 sm:px-6">
               <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-                {linkedConversations.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {linkedConversations.map((conversation) => (
-                      <LinkedConversationChip
-                        key={conversation._id}
-                        conversation={conversation}
-                        onRemove={() => removeLinkedConversation(conversation._id)}
-                      />
-                    ))}
-                  </div>
-                ) : null}
-
                 <div className="space-y-6">
                   {messages.map((message) => (
                     <div
@@ -297,36 +274,29 @@ export default function Chat() {
                         className={cn(
                           "max-w-[85%] rounded-3xl px-5 py-4 shadow-sm sm:max-w-[70%]",
                           message.role === "user"
-                            ? "bg-primary text-primary-foreground"
+                            ? "bg-[#6d63d9] text-white dark:bg-[#7a70eb]"
                             : "border border-border bg-card text-foreground"
                         )}
                       >
-                        <div
-                          className={cn(
-                            "prose prose-sm max-w-none",
-                            message.role === "user"
-                              ? "prose-invert"
-                              : "prose-foreground dark:prose-invert",
-                            "prose-p:my-1 prose-li:my-0.5 prose-ul:my-2 prose-ol:my-2",
-                            "prose-headings:mt-3 prose-headings:mb-2"
-                          )}
-                        >
-                          <Markdown>{message.content}</Markdown>
-                        </div>
+                        {message.role === "assistant" && !message.content.trim() ? (
+                          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                        ) : (
+                          <div
+                            className={cn(
+                              "prose prose-sm max-w-none",
+                              message.role === "user"
+                                ? "prose-invert"
+                                : "prose-foreground dark:prose-invert",
+                              "prose-p:my-1 prose-li:my-0.5 prose-ul:my-2 prose-ol:my-2",
+                              "prose-headings:mt-3 prose-headings:mb-2"
+                            )}
+                          >
+                            <Markdown>{message.content}</Markdown>
+                          </div>
+                        )}
                       </div>
                     </div>
                   ))}
-
-                  {isLoading ? (
-                    <div className="flex gap-3 justify-start">
-                      <div className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
-                        <Sparkles className="size-5" />
-                      </div>
-                      <div className="rounded-3xl border border-border bg-card px-5 py-4 shadow-sm">
-                        <Loader2 className="size-4 animate-spin text-muted-foreground" />
-                      </div>
-                    </div>
-                  ) : null}
 
                   <div ref={messagesEndRef} />
                 </div>
@@ -475,32 +445,38 @@ function CoachComposer({
 }) {
   return (
     <div className="space-y-3">
-      {compact ? (
-        <div className="flex items-center justify-end">
-          <Button
-            type="button"
-            onClick={onOpenConversationPicker}
-            className="h-11 rounded-xl"
-          >
-            <FolderOpen className="size-4" />
-            {pickerButtonLabel}
-          </Button>
+      {compact || conversations.length >= 0 ? (
+        <div className="flex items-center gap-3">
+          <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+            <div className="flex min-w-max items-center gap-2">
+              {conversations.map((conversation) => (
+                <LinkedConversationChip
+                  key={conversation._id}
+                  conversation={conversation}
+                  onRemove={() => onRemoveConversation(conversation._id)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {compact ? (
+            <div className="flex h-11 shrink-0 items-center text-sm font-medium text-black dark:text-white">
+              {pickerButtonLabel}
+            </div>
+          ) : (
+            <Button
+              type="button"
+              onClick={onOpenConversationPicker}
+              className="h-11 shrink-0 rounded-xl"
+            >
+              <FolderOpen className="size-4" />
+              {pickerButtonLabel}
+            </Button>
+          )}
         </div>
       ) : null}
 
-      <div className="rounded-2xl border border-border bg-card p-3 shadow-sm">
-        {conversations.length > 0 ? (
-          <div className="mb-3 flex flex-wrap gap-2 border-b border-border pb-3">
-            {conversations.map((conversation) => (
-              <LinkedConversationChip
-                key={conversation._id}
-                conversation={conversation}
-                onRemove={() => onRemoveConversation(conversation._id)}
-              />
-            ))}
-          </div>
-        ) : null}
-
+      <div className="rounded-2xl border border-border bg-card/50 p-3 shadow-sm">
         <form onSubmit={onSubmit} className="flex items-center gap-2">
           <Input
             ref={inputRef}
@@ -508,7 +484,7 @@ function CoachComposer({
             onChange={(e) => onChange(e.target.value)}
             placeholder="Ask Audora"
             disabled={isLoading}
-            className="h-12 border-0 bg-transparent px-3 text-base text-foreground shadow-none focus-visible:ring-0"
+            className="h-12 rounded-none border-0 bg-transparent px-3 text-base text-foreground shadow-none dark:bg-transparent focus-visible:ring-0"
           />
           <button
             type="button"

--- a/apps/web/app/routes/dashboard/index.tsx
+++ b/apps/web/app/routes/dashboard/index.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import { api } from "@audora/backend/convex/_generated/api";
-import { useAuth } from "@clerk/react-router";
-import { useMutation } from "convex/react";
-import { Loader2, Phone, Plus, Upload, Users } from "lucide-react";
+import { useAuth, useUser } from "@clerk/react-router";
+import { useMutation, useQuery } from "convex/react";
+import {
+    Loader2,
+    MessageSquare,
+    Plus,
+    Sparkles,
+    Upload,
+    Wand2,
+} from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
@@ -13,8 +20,10 @@ import { Button } from "../../components/ui/button";
 
 export default function Page() {
   const { isSignedIn } = useAuth();
+  const { user } = useUser();
   const navigate = useNavigate();
   const createConversation = useMutation(api.conversations.create);
+  const weeklyProgress = useQuery(api.analytics.getWeeklyProgress);
   const [isCreating, setIsCreating] = useState(false);
 
   if (!isSignedIn) {
@@ -37,47 +46,55 @@ export default function Page() {
     }
   };
 
+  const firstName =
+    user?.firstName ||
+    user?.fullName?.split(" ")[0] ||
+    user?.primaryEmailAddress?.emailAddress?.split("@")[0] ||
+    "there";
+
+  const historyActions = (
+    <>
+      <Button
+        onClick={() => navigate("/dashboard/import")}
+        disabled={isCreating}
+        size="lg"
+        variant="outline"
+        className="flex-1 sm:flex-none">
+        <Upload className="w-4 h-4 mr-2" />
+        Import Audio
+      </Button>
+      <Button
+        onClick={handleStartRecording}
+        disabled={isCreating}
+        size="lg"
+        className="flex-1 sm:flex-none">
+        {isCreating ? (
+          <>
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Creating...
+          </>
+        ) : (
+          <>
+            <Plus className="w-4 h-4 mr-2" />
+            New Conversation
+          </>
+        )}
+      </Button>
+    </>
+  );
+
   return (
     <div className="flex flex-col h-[calc(100vh-4rem)]">
-      {/* Header */}
-      <div className="border-b border-border bg-card/50 backdrop-blur-sm">
+      <div className="border-b border-border bg-sidebar dark:bg-card">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
               <h1 className="text-2xl font-bold text-foreground mb-1">
-                Dashboard
+                Welcome back, {firstName}
               </h1>
               <p className="text-sm text-muted-foreground">
-                Welcome back! Start a new conversation or view your history
+                Start a new conversation or view your history
               </p>
-            </div>
-            <div className="flex gap-2 w-full sm:w-auto">
-              <Button
-                onClick={() => navigate("/dashboard/import")}
-                disabled={isCreating}
-                size="lg"
-                variant="outline"
-                className="flex-1 sm:flex-none">
-                <Upload className="w-4 h-4 mr-2" />
-                Import Audio
-              </Button>
-              <Button
-                onClick={handleStartRecording}
-                disabled={isCreating}
-                size="lg"
-                className="flex-1 sm:flex-none">
-                {isCreating ? (
-                  <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    Creating...
-                  </>
-                ) : (
-                  <>
-                    <Plus className="w-4 h-4 mr-2" />
-                    New Conversation
-                  </>
-                )}
-              </Button>
             </div>
           </div>
         </div>
@@ -85,47 +102,140 @@ export default function Page() {
 
       {/* Main Content */}
       <div className="flex-1 overflow-auto">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-          <h2 className="text-lg font-semibold text-foreground mb-4">Recent Conversations</h2>
-          <ConversationHistory />
-        </div>
-      </div>
+        <div className="max-w-7xl mx-auto space-y-7 px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-foreground">
+              Weekly Progress
+            </h2>
+            <WeeklyProgressCards progress={weeklyProgress} />
+          </section>
 
-      {/* Quick Actions Footer - Mobile Only */}
-      <div className="sm:hidden border-t border-border bg-card/50 backdrop-blur-sm">
-        <div className="px-4 py-3">
-          <div className="flex items-center justify-around gap-2">
-            <a
-              href="/dashboard/network"
-              className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors">
-              <Users className="w-5 h-5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Network</span>
-            </a>
-
-            <a
-              href={`tel:${import.meta.env.VITE_TWILIO_PHONE_NUMBER || ""}`}
-              className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors">
-              <Phone className="w-5 h-5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Call</span>
-            </a>
-
-            <a
-              href="https://wa.me/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors">
-              <svg
-                className="w-5 h-5 text-muted-foreground"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                xmlns="http://www.w3.org/2000/svg">
-                <path d="M17.6 6.32A8.78 8.78 0 0 0 12.23 4 8.91 8.91 0 0 0 3.39 13a9 9 0 0 0 1.28 4.57L3.26 22l4.51-1.17a8.91 8.91 0 0 0 13.14-7.72 8.83 8.83 0 0 0-3.31-6.79ZM12.23 20.26a7.43 7.43 0 0 1-3.8-1l-.27-.16-2.82.74.76-2.76-.18-.28a7.42 7.42 0 0 1-1.17-4 7.4 7.4 0 0 1 7.44-7.44 7.54 7.54 0 0 1 5.34 2.2 7.31 7.31 0 0 1 2.17 5.25 7.43 7.43 0 0 1-7.47 7.45Zm4.07-5.55c-.22-.11-1.32-.65-1.53-.73s-.35-.11-.5.11-.58.73-.71.88-.26.17-.48.06a6 6 0 0 1-1.78-1.09 6.81 6.81 0 0 1-1.23-1.53c-.13-.22 0-.34.1-.45s.22-.25.33-.38a1.41 1.41 0 0 0 .22-.36.41.41 0 0 0 0-.38c0-.11-.5-1.2-.69-1.65s-.36-.37-.5-.38h-.42a.82.82 0 0 0-.58.27 2.41 2.41 0 0 0-.78 1.81 4.28 4.28 0 0 0 .88 2.25 9.6 9.6 0 0 0 3.73 3.26 12.32 12.32 0 0 0 1.24.46 3 3 0 0 0 1.38.09 2.3 2.3 0 0 0 1.5-1.06 1.85 1.85 0 0 0 .13-1.06c-.05-.08-.19-.13-.41-.24Z" />
-              </svg>
-              <span className="text-xs text-muted-foreground">WhatsApp</span>
-            </a>
-          </div>
+          <section>
+            <h2 className="text-lg font-semibold text-foreground mb-4">History</h2>
+            <div className="rounded-2xl border border-border bg-sidebar dark:bg-card">
+              <div className="px-4 py-4 sm:px-6 sm:py-6">
+                <ConversationHistory headerActions={historyActions} />
+              </div>
+            </div>
+          </section>
         </div>
       </div>
     </div>
   );
+}
+
+function WeeklyProgressCards({
+  progress,
+}: {
+  progress:
+    | {
+        conversations: {
+          current: number;
+          previous: number;
+          change: number;
+        };
+        confidence: {
+          current: number | null;
+          previous: number | null;
+          changePercent: number | null;
+        };
+        fillerWords: {
+          currentRate: number | null;
+          previousRate: number | null;
+          reductionPercent: number | null;
+        };
+      }
+    | null
+    | undefined;
+}) {
+  const isLoading = progress === undefined;
+
+  const cards = [
+    {
+      title: "Practice Sessions",
+      value: isLoading ? "..." : `${progress?.conversations.current ?? 0} this week`,
+      description:
+        progress?.conversations.change === undefined
+          ? "Conversation activity will appear here."
+          : formatDelta(progress.conversations.change, "from last week"),
+      icon: MessageSquare,
+    },
+    {
+      title: "Confident Tone",
+      value: isLoading
+        ? "..."
+        : progress?.confidence.changePercent !== null &&
+            progress?.confidence.changePercent !== undefined
+          ? `${formatSigned(progress.confidence.changePercent)}%`
+          : progress?.confidence.current !== null &&
+              progress?.confidence.current !== undefined
+            ? `${progress.confidence.current}/100`
+            : "No score yet",
+      description:
+        progress?.confidence.changePercent !== null &&
+        progress?.confidence.changePercent !== undefined
+          ? progress.confidence.changePercent >= 0
+            ? "Improvement from your previous week."
+            : "Change from your previous week."
+          : "Based on your average confidence score.",
+      icon: Sparkles,
+    },
+    {
+      title: "Cleaner Speech",
+      value: isLoading
+        ? "..."
+        : progress?.fillerWords.reductionPercent !== null &&
+            progress?.fillerWords.reductionPercent !== undefined
+          ? `${formatSigned(progress.fillerWords.reductionPercent)}%`
+          : progress?.fillerWords.currentRate !== null &&
+              progress?.fillerWords.currentRate !== undefined
+            ? `${progress.fillerWords.currentRate}/min`
+            : "No rate yet",
+      description:
+        progress?.fillerWords.reductionPercent !== null &&
+        progress?.fillerWords.reductionPercent !== undefined
+          ? progress.fillerWords.reductionPercent >= 0
+            ? "Filler word rate reduction from last week."
+            : "Filler word rate change from last week."
+          : "Average filler words per minute this week.",
+      icon: Wand2,
+    },
+  ];
+
+  return (
+    <div className="-mx-4 overflow-x-auto px-4 pb-1 md:mx-0 md:overflow-visible md:px-0 md:pb-0">
+      <div className="flex snap-x snap-mandatory gap-3 md:grid md:grid-cols-3">
+        {cards.map((card) => {
+          const Icon = card.icon;
+
+          return (
+            <div
+              key={card.title}
+              className="min-w-[260px] snap-start rounded-lg border border-border bg-card px-5 py-4 shadow-sm dark:bg-card md:min-w-0"
+            >
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <p className="text-sm font-medium text-muted-foreground">{card.title}</p>
+                <Icon className="size-4 text-primary" />
+              </div>
+              <p className="text-xl font-semibold text-primary">{card.value}</p>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                {card.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatSigned(value: number) {
+  if (value > 0) return `+${value}`;
+  return `${value}`;
+}
+
+function formatDelta(value: number, suffix: string) {
+  if (value > 0) return `+${value} ${suffix}`;
+  if (value < 0) return `${value} ${suffix}`;
+  return `No change ${suffix}`;
 }

--- a/apps/web/app/routes/dashboard/settings.tsx
+++ b/apps/web/app/routes/dashboard/settings.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Copy, Check } from "lucide-react";
 import SubscriptionStatus from "~/components/subscription-status";
 import ConnectionGraph from "~/components/network/ConnectionGraph";
+import { ThemeToggle } from "~/components/ThemeToggle";
 
 export default function Page() {
   const [activeTab, setActiveTab] = useState<"profile" | "network" | "subscription">("profile");
@@ -78,6 +79,19 @@ export default function Page() {
                 <div>
                   <h2 className="text-2xl font-bold text-white">Profile Settings</h2>
                   <p className="text-gray-400">Manage your profile information here.</p>
+                </div>
+
+                {/* Appearance Section */}
+                <div className="bg-gray-800/50 rounded-lg p-6 border border-gray-700">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold text-white mb-2">Appearance</h3>
+                      <p className="text-gray-400">
+                        Switch between light and dark mode.
+                      </p>
+                    </div>
+                    <ThemeToggle />
+                  </div>
                 </div>
 
                 {/* Invite Code Section */}

--- a/apps/web/app/routes/dashboard/view.$id.tsx
+++ b/apps/web/app/routes/dashboard/view.$id.tsx
@@ -188,7 +188,7 @@ export default function ConversationDetailPage() {
     <AudioPlaybackProvider>
     <div className="flex flex-col h-full bg-background">
       {/* Enhanced Header */}
-      <div className="bg-card backdrop-blur-sm">
+      <div className="relative bg-sidebar backdrop-blur-sm before:absolute before:inset-y-0 before:-left-px before:w-px before:bg-sidebar dark:bg-card dark:before:bg-card">
         <div className="px-6 py-5">
           <div className="flex items-start justify-between gap-4">
             {/* Left section */}
@@ -246,17 +246,17 @@ export default function ConversationDetailPage() {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-1 min-h-0 flex-col gap-0">
-        <div className="border-b-2 border-border bg-card px-4 sm:px-6">
+        <div className="relative border-b-2 border-border bg-sidebar px-4 before:absolute before:inset-y-0 before:-left-px before:w-px before:bg-sidebar dark:bg-card dark:before:bg-card sm:px-6">
           <TabsList className="h-auto w-full justify-start rounded-none bg-transparent p-0">
             <TabsTrigger
               value="analytics"
-              className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-0 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
+              className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-0 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 hover:bg-transparent focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none dark:data-[state=active]:border-b-primary dark:data-[state=active]:bg-transparent dark:data-[state=active]:text-primary sm:px-4"
             >
               Summary
             </TabsTrigger>
             <TabsTrigger
               value="transcript"
-              className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-5 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
+              className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-5 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 hover:bg-transparent focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none dark:data-[state=active]:border-b-primary dark:data-[state=active]:bg-transparent dark:data-[state=active]:text-primary sm:px-4"
             >
               Transcript
             </TabsTrigger>
@@ -291,8 +291,8 @@ export default function ConversationDetailPage() {
               </TranscriptPlayer>
             </div>
 
-            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm">
-              <div className="shrink-0 border-b border-primary/20 pb-3">
+            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-border bg-sidebar p-5 shadow-sm dark:bg-card">
+              <div className="shrink-0 border-b border-border/70 pb-3">
                 <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Focus areas from this conversation.

--- a/apps/web/app/routes/dashboard/view.$id.tsx
+++ b/apps/web/app/routes/dashboard/view.$id.tsx
@@ -2,6 +2,7 @@ import { api } from "@audora/backend/convex/_generated/api";
 import type { Id } from "@audora/backend/convex/_generated/dataModel";
 import { useQuery } from "convex/react";
 import { AlertCircle, ArrowLeft, Calendar, Clock, Loader2, MoveUpLeft, Share2, Users } from "lucide-react";
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { PersonalizedFeedback } from "~/components/analytics/PersonalizedFeedback";
 import { AnalyticsPanel } from "~/components/dashboard/analytics-panel";
@@ -18,6 +19,7 @@ import { getConversationDisplayTitle } from "~/lib/conversation-context";
 export default function ConversationDetailPage() {
   const { id } = useParams<{ id: Id<"conversations"> }>();
   const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState("analytics");
 
   // Fetch conversation data
   const conversation = useQuery(
@@ -243,7 +245,7 @@ export default function ConversationDetailPage() {
         </div>
       </div>
 
-      <Tabs defaultValue="analytics" className="flex flex-1 min-h-0 flex-col gap-0">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-1 min-h-0 flex-col gap-0">
         <div className="border-b-2 border-border bg-card px-4 sm:px-6">
           <TabsList className="h-auto w-full justify-start rounded-none bg-transparent p-0">
             <TabsTrigger
@@ -262,7 +264,11 @@ export default function ConversationDetailPage() {
         </div>
 
         <TabsContent value="analytics" className="min-h-0 flex-1 overflow-hidden p-4 sm:p-6">
-          <AnalyticsPanel showHeader={false} conversationId={id as Id<"conversations">} />
+          <AnalyticsPanel
+            showHeader={false}
+            conversationId={id as Id<"conversations">}
+            onOpenTranscript={() => setActiveTab("transcript")}
+          />
         </TabsContent>
 
         <TabsContent value="transcript" className="min-h-0 flex-1 overflow-hidden p-4 sm:p-6">
@@ -285,23 +291,25 @@ export default function ConversationDetailPage() {
               </TranscriptPlayer>
             </div>
 
-            <aside className="min-h-0 overflow-y-auto rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm custom-scrollbar xl:sticky xl:top-0 xl:self-start">
-              <div className="mb-4 border-b border-primary/20 pb-3">
+            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm">
+              <div className="shrink-0 border-b border-primary/20 pb-3">
                 <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Focus areas from this conversation.
                 </p>
               </div>
-              {currentUser ? (
-                <PersonalizedFeedback
-                  conversationId={id as Id<"conversations">}
-                  userId={currentUser._id}
-                />
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  Sign in to view personalized insights.
-                </p>
-              )}
+              <div className="mt-4 min-h-0 flex-1 overflow-y-auto pr-2 custom-scrollbar">
+                {currentUser ? (
+                  <PersonalizedFeedback
+                    conversationId={id as Id<"conversations">}
+                    userId={currentUser._id}
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Sign in to view personalized insights.
+                  </p>
+                )}
+              </div>
             </aside>
           </div>
         </TabsContent>

--- a/apps/web/app/routes/dashboard/view.$id.tsx
+++ b/apps/web/app/routes/dashboard/view.$id.tsx
@@ -1,8 +1,7 @@
 import { api } from "@audora/backend/convex/_generated/api";
 import type { Id } from "@audora/backend/convex/_generated/dataModel";
 import { useQuery } from "convex/react";
-import { AlertCircle, ArrowLeft, BarChart3, Calendar, Clock, Loader2, MessageSquare, MoveUpLeft, Share2, Users, X } from "lucide-react";
-import { useState } from "react";
+import { AlertCircle, ArrowLeft, Calendar, Clock, Loader2, MessageSquare, MoveUpLeft, Share2, Users } from "lucide-react";
 import { useNavigate, useParams } from "react-router";
 import { AnalyticsPanel } from "~/components/dashboard/analytics-panel";
 import { TranscriptChatbot } from "~/components/dashboard/transcript-chatbot";
@@ -11,22 +10,13 @@ import CurrentView from "~/components/recording/CurrentView";
 import PendingView from "~/components/recording/PendingView";
 import TranscriptPlayer from "~/components/transcript/TranscriptPlayer";
 import { Button } from "~/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { AudioPlaybackProvider } from "~/hooks/use-audio-playback";
 import { getConversationDisplayTitle } from "~/lib/conversation-context";
 
 export default function ConversationDetailPage() {
   const { id } = useParams<{ id: Id<"conversations"> }>();
   const navigate = useNavigate();
-  const [isAnalyticsOpen, setIsAnalyticsOpen] = useState(false);
-  const [isClosing, setIsClosing] = useState(false);
-
-  const closeAnalytics = () => {
-    setIsClosing(true);
-    setTimeout(() => {
-      setIsAnalyticsOpen(false);
-      setIsClosing(false);
-    }, 300);
-  };
 
   // Fetch conversation data
   const conversation = useQuery(
@@ -262,86 +252,46 @@ export default function ConversationDetailPage() {
         </div>
       </div>
 
-      {/* Two-column layout - Responsive */}
-      <div className="flex flex-col lg:flex-row flex-1 overflow-hidden">
-        {/* Left column: TranscriptPlayer (audio + transcript) */}
-        <div className="flex-1 lg:flex-[3] border-b lg:border-b-0 lg:border-r border-border flex flex-col h-full min-h-0 relative">
-          <div className="flex flex-col p-4 sm:p-6 h-full min-h-0">
-            <TranscriptPlayer
-              conversationId={id as Id<"conversations">}
-              getUserName={(userId) => {
-                if (!userId) return "Unknown";
-                if (initiatorUser && userId === conversation?.initiatorUserId) {
-                  return initiatorUser.name || "Speaker 1";
-                }
-                if (scannerUser && userId === conversation?.scannerUserId) {
-                  return scannerUser.name || "Speaker 2";
-                }
-                return "Speaker";
-              }}
+      <Tabs defaultValue="analytics" className="flex flex-1 min-h-0 flex-col gap-0">
+        <div className="border-b border-border bg-background px-4 sm:px-6">
+          <TabsList className="h-auto w-full justify-start rounded-none bg-transparent p-0">
+            <TabsTrigger
+              value="analytics"
+              className="h-12 flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-0 pb-3 pt-4 text-base text-muted-foreground shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
             >
-              <TranscriptChatbot conversationId={id as Id<"conversations">} />
-            </TranscriptPlayer>
-          </div>
+              Analytics
+            </TabsTrigger>
+            <TabsTrigger
+              value="transcript"
+              className="h-12 flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-5 pb-3 pt-4 text-base text-muted-foreground shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
+            >
+              Transcript
+            </TabsTrigger>
+          </TabsList>
         </div>
 
-        {/* Right column: Analytics - hidden on mobile, shown in modal */}
-        <div className="hidden lg:flex lg:flex-col lg:flex-[2] h-full min-h-0">
-          <div className="p-6 flex flex-col h-full min-h-0">
-            <div className="bg-card border border-border rounded-lg p-6 flex flex-col h-full min-h-0">
-              <h2 className="text-lg font-semibold text-foreground mb-4 shrink-0">
-                Analytics
-              </h2>
-              <div className="flex-1 min-h-0">
-                <AnalyticsPanel showHeader={false} conversationId={id as Id<"conversations">} />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+        <TabsContent value="analytics" className="min-h-0 flex-1 overflow-hidden p-4 sm:p-6">
+          <AnalyticsPanel showHeader={false} conversationId={id as Id<"conversations">} />
+        </TabsContent>
 
-      {/* Mobile bottom nav bar - shown on small screens */}
-      <div className="lg:hidden border-t border-border bg-card backdrop-blur-sm p-3 shrink-0">
-        <Button
-          variant="outline"
-          className="w-full gap-2"
-          onClick={() => setIsAnalyticsOpen(true)}
-        >
-          <BarChart3 className="w-4 h-4" />
-          View Analytics
-        </Button>
-      </div>
-
-      {/* Mobile Analytics slide-in panel */}
-      {isAnalyticsOpen && (
-        <div className="lg:hidden fixed inset-0 z-50">
-          {/* Backdrop */}
-          <div
-            className={`absolute inset-0 bg-black/50 transition-opacity duration-300 ${isClosing ? 'opacity-0' : 'opacity-100'}`}
-            onClick={closeAnalytics}
-          />
-          {/* Panel */}
-          <div className={`absolute right-0 top-0 h-full w-full max-w-md bg-background shadow-xl transition-transform duration-300 ${isClosing ? 'translate-x-full' : 'translate-x-0 animate-in slide-in-from-right'}`}>
-            <div className="flex flex-col h-full">
-              <div className="flex items-center justify-between p-4 border-b border-border">
-                <h2 className="text-lg font-semibold text-foreground">Analytics</h2>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={closeAnalytics}
-                >
-                  <X className="w-5 h-5" />
-                </Button>
-              </div>
-              <div className="flex-1 overflow-auto p-6 pr-3 custom-scrollbar">
-                <div className="bg-card border border-border rounded-lg p-6">
-                  <AnalyticsPanel showHeader={false} conversationId={id as Id<"conversations">} />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+        <TabsContent value="transcript" className="min-h-0 flex-1 overflow-hidden p-4 sm:p-6">
+          <TranscriptPlayer
+            conversationId={id as Id<"conversations">}
+            getUserName={(userId) => {
+              if (!userId) return "Unknown";
+              if (initiatorUser && userId === conversation?.initiatorUserId) {
+                return initiatorUser.name || "Speaker 1";
+              }
+              if (scannerUser && userId === conversation?.scannerUserId) {
+                return scannerUser.name || "Speaker 2";
+              }
+              return "Speaker";
+            }}
+          >
+            <TranscriptChatbot conversationId={id as Id<"conversations">} />
+          </TranscriptPlayer>
+        </TabsContent>
+      </Tabs>
     </div>
     </AudioPlaybackProvider>
   );

--- a/apps/web/app/routes/dashboard/view.$id.tsx
+++ b/apps/web/app/routes/dashboard/view.$id.tsx
@@ -12,6 +12,14 @@ import CurrentView from "~/components/recording/CurrentView";
 import PendingView from "~/components/recording/PendingView";
 import TranscriptPlayer from "~/components/transcript/TranscriptPlayer";
 import { Button } from "~/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { AudioPlaybackProvider } from "~/hooks/use-audio-playback";
 import { getConversationDisplayTitle } from "~/lib/conversation-context";
@@ -247,7 +255,8 @@ export default function ConversationDetailPage() {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-1 min-h-0 flex-col gap-0">
         <div className="relative border-b-2 border-border bg-sidebar px-4 before:absolute before:inset-y-0 before:-left-px before:w-px before:bg-sidebar dark:bg-card dark:before:bg-card sm:px-6">
-          <TabsList className="h-auto w-full justify-start rounded-none bg-transparent p-0">
+          <div className="flex items-center justify-between gap-4">
+          <TabsList className="h-auto justify-start rounded-none bg-transparent p-0">
             <TabsTrigger
               value="analytics"
               className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-0 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 hover:bg-transparent focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none dark:data-[state=active]:border-b-primary dark:data-[state=active]:bg-transparent dark:data-[state=active]:text-primary sm:px-4"
@@ -261,6 +270,36 @@ export default function ConversationDetailPage() {
               Transcript
             </TabsTrigger>
           </TabsList>
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-9 shrink-0 bg-transparent text-muted-foreground hover:bg-transparent hover:text-primary dark:hover:bg-transparent xl:hidden"
+              >
+                Actionable Insights
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-[22rem] max-w-[calc(100vw-2rem)] bg-sidebar p-0 dark:bg-card">
+              <SheetHeader className="border-b border-border/70 p-5">
+                <SheetTitle>Actionable Insights</SheetTitle>
+                <SheetDescription>Focus areas from this conversation.</SheetDescription>
+              </SheetHeader>
+              <div className="min-h-0 flex-1 overflow-y-auto p-5 pr-7 custom-scrollbar">
+                {currentUser ? (
+                  <PersonalizedFeedback
+                    conversationId={id as Id<"conversations">}
+                    userId={currentUser._id}
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Sign in to view personalized insights.
+                  </p>
+                )}
+              </div>
+            </SheetContent>
+          </Sheet>
+          </div>
         </div>
 
         <TabsContent value="analytics" className="min-h-0 flex-1 overflow-hidden p-4 sm:p-6">
@@ -291,7 +330,7 @@ export default function ConversationDetailPage() {
               </TranscriptPlayer>
             </div>
 
-            <aside className="flex h-full min-h-0 flex-col rounded-xl border border-border bg-sidebar p-5 shadow-sm dark:bg-card">
+            <aside className="hidden h-full min-h-0 flex-col rounded-xl border border-border bg-sidebar p-5 shadow-sm dark:bg-card xl:flex">
               <div className="shrink-0 border-b border-border/70 pb-3">
                 <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
                 <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/app/routes/dashboard/view.$id.tsx
+++ b/apps/web/app/routes/dashboard/view.$id.tsx
@@ -1,8 +1,9 @@
 import { api } from "@audora/backend/convex/_generated/api";
 import type { Id } from "@audora/backend/convex/_generated/dataModel";
 import { useQuery } from "convex/react";
-import { AlertCircle, ArrowLeft, Calendar, Clock, Loader2, MessageSquare, MoveUpLeft, Share2, Users } from "lucide-react";
+import { AlertCircle, ArrowLeft, Calendar, Clock, Loader2, MoveUpLeft, Share2, Users } from "lucide-react";
 import { useNavigate, useParams } from "react-router";
+import { PersonalizedFeedback } from "~/components/analytics/PersonalizedFeedback";
 import { AnalyticsPanel } from "~/components/dashboard/analytics-panel";
 import { TranscriptChatbot } from "~/components/dashboard/transcript-chatbot";
 import { ExportDialog } from "~/components/export/ExportDialog";
@@ -45,6 +46,7 @@ export default function ConversationDetailPage() {
     api.users.get,
     conversation?.scannerUserId ? { id: conversation.scannerUserId } : "skip"
   );
+  const currentUser = useQuery(api.users.getCurrentUser);
 
   // Loading state - only wait for conversation data initially
   if (conversation === undefined) {
@@ -184,31 +186,24 @@ export default function ConversationDetailPage() {
     <AudioPlaybackProvider>
     <div className="flex flex-col h-full bg-background">
       {/* Enhanced Header */}
-      <div className="border-b border-border bg-card backdrop-blur-sm shadow-sm">
+      <div className="bg-card backdrop-blur-sm">
         <div className="px-6 py-5">
           <div className="flex items-start justify-between gap-4">
             {/* Left section */}
-            <div className="flex items-start gap-4 flex-1 min-w-0">
-              <Button
-                variant="ghost"
-                size="sm"
+            <div className="flex-1 min-w-0">
+              <button
+                type="button"
                 onClick={() => navigate("/dashboard")}
-                className="gap-2 shrink-0 hover:bg-muted/80">
-                <ArrowLeft className="w-4 h-4" />
+                className="mb-3 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ArrowLeft className="h-3.5 w-3.5" />
                 Back
-              </Button>
+              </button>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-3 mb-2">
                   <h1 className="text-2xl font-bold text-foreground truncate">
                     {getConversationTitle()}
                   </h1>
-                  <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${
-                    conversation.status === 'ended' 
-                      ? 'bg-green-500/10 text-green-700 dark:text-green-400 border border-green-500/20' 
-                      : 'bg-blue-500/10 text-blue-700 dark:text-blue-400 border border-blue-500/20'
-                  }`}>
-                    {conversation.status === 'ended' ? 'Completed' : 'Active'}
-                  </span>
                 </div>
                 <div className="flex items-center gap-5 text-sm text-muted-foreground flex-wrap">
                   <div className="flex items-center gap-1.5">
@@ -222,10 +217,6 @@ export default function ConversationDetailPage() {
                   <div className="flex items-center gap-1.5">
                     <Users className="w-4 h-4" />
                     <span>{participantCount} {participantCount === 1 ? 'participant' : 'participants'}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <MessageSquare className="w-4 h-4" />
-                    <span>{transcript?.length || 0} turns</span>
                   </div>
                 </div>
               </div>
@@ -253,17 +244,17 @@ export default function ConversationDetailPage() {
       </div>
 
       <Tabs defaultValue="analytics" className="flex flex-1 min-h-0 flex-col gap-0">
-        <div className="border-b border-border bg-background px-4 sm:px-6">
+        <div className="border-b-2 border-border bg-card px-4 sm:px-6">
           <TabsList className="h-auto w-full justify-start rounded-none bg-transparent p-0">
             <TabsTrigger
               value="analytics"
-              className="h-12 flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-0 pb-3 pt-4 text-base text-muted-foreground shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
+              className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-0 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
             >
-              Analytics
+              Summary
             </TabsTrigger>
             <TabsTrigger
               value="transcript"
-              className="h-12 flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-5 pb-3 pt-4 text-base text-muted-foreground shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
+              className="h-12 flex-none rounded-none border-0 border-b-4 border-transparent bg-transparent px-5 pb-3 pt-4 text-base text-muted-foreground shadow-none outline-none ring-0 focus-visible:border-x-0 focus-visible:border-t-0 focus-visible:border-b-primary focus-visible:outline-none focus-visible:ring-0 data-[state=active]:border-x-0 data-[state=active]:border-t-0 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none sm:px-4"
             >
               Transcript
             </TabsTrigger>
@@ -275,21 +266,44 @@ export default function ConversationDetailPage() {
         </TabsContent>
 
         <TabsContent value="transcript" className="min-h-0 flex-1 overflow-hidden p-4 sm:p-6">
-          <TranscriptPlayer
-            conversationId={id as Id<"conversations">}
-            getUserName={(userId) => {
-              if (!userId) return "Unknown";
-              if (initiatorUser && userId === conversation?.initiatorUserId) {
-                return initiatorUser.name || "Speaker 1";
-              }
-              if (scannerUser && userId === conversation?.scannerUserId) {
-                return scannerUser.name || "Speaker 2";
-              }
-              return "Speaker";
-            }}
-          >
-            <TranscriptChatbot conversationId={id as Id<"conversations">} />
-          </TranscriptPlayer>
+          <div className="grid h-full min-h-0 gap-5 xl:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="min-h-0">
+              <TranscriptPlayer
+                conversationId={id as Id<"conversations">}
+                getUserName={(userId) => {
+                  if (!userId) return "Unknown";
+                  if (initiatorUser && userId === conversation?.initiatorUserId) {
+                    return initiatorUser.name || "Speaker 1";
+                  }
+                  if (scannerUser && userId === conversation?.scannerUserId) {
+                    return scannerUser.name || "Speaker 2";
+                  }
+                  return "Speaker";
+                }}
+              >
+                <TranscriptChatbot conversationId={id as Id<"conversations">} />
+              </TranscriptPlayer>
+            </div>
+
+            <aside className="min-h-0 overflow-y-auto rounded-xl border border-primary/20 bg-primary/5 p-5 shadow-sm custom-scrollbar xl:sticky xl:top-0 xl:self-start">
+              <div className="mb-4 border-b border-primary/20 pb-3">
+                <h3 className="text-base font-semibold text-foreground">Actionable Insights</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Focus areas from this conversation.
+                </p>
+              </div>
+              {currentUser ? (
+                <PersonalizedFeedback
+                  conversationId={id as Id<"conversations">}
+                  userId={currentUser._id}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Sign in to view personalized insights.
+                </p>
+              )}
+            </aside>
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/app/routes/record.tsx
+++ b/apps/web/app/routes/record.tsx
@@ -1,13 +1,13 @@
 import { api } from "@audora/backend/convex/_generated/api";
 import { useAuth } from "@clerk/react-router";
 import { useMutation } from "convex/react";
-import { Loader2, Phone, Plus, Users } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
-import { buildConversationContextLabel } from "../lib/conversation-context";
 import ConversationHistory from "../components/ConversationHistory";
 import { Button } from "../components/ui/button";
+import { buildConversationContextLabel } from "../lib/conversation-context";
 
 export default function RecordPage() {
   const { isSignedIn } = useAuth();
@@ -76,42 +76,6 @@ export default function RecordPage() {
       <div className="flex-1 overflow-auto">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
           <ConversationHistory />
-        </div>
-      </div>
-
-      {/* Quick Actions Footer - Mobile Only */}
-      <div className="sm:hidden border-t border-border bg-card/50 backdrop-blur-sm">
-        <div className="px-4 py-3">
-          <div className="flex items-center justify-around gap-2">
-            <a
-              href="/dashboard/network"
-              className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors">
-              <Users className="w-5 h-5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Network</span>
-            </a>
-
-            <a
-              href={`tel:${import.meta.env.VITE_TWILIO_PHONE_NUMBER || ""}`}
-              className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors">
-              <Phone className="w-5 h-5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Call</span>
-            </a>
-
-            <a
-              href="https://wa.me/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors">
-              <svg
-                className="w-5 h-5 text-muted-foreground"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                xmlns="http://www.w3.org/2000/svg">
-                <path d="M17.6 6.32A8.78 8.78 0 0 0 12.23 4 8.91 8.91 0 0 0 3.39 13a9 9 0 0 0 1.28 4.57L3.26 22l4.51-1.17a8.91 8.91 0 0 0 13.14-7.72 8.83 8.83 0 0 0-3.31-6.79ZM12.23 20.26a7.43 7.43 0 0 1-3.8-1l-.27-.16-2.82.74.76-2.76-.18-.28a7.42 7.42 0 0 1-1.17-4 7.4 7.4 0 0 1 7.44-7.44 7.54 7.54 0 0 1 5.34 2.2 7.31 7.31 0 0 1 2.17 5.25 7.43 7.43 0 0 1-7.47 7.45Zm4.07-5.55c-.22-.11-1.32-.65-1.53-.73s-.35-.11-.5.11-.58.73-.71.88-.26.17-.48.06a6 6 0 0 1-1.78-1.09 6.81 6.81 0 0 1-1.23-1.53c-.13-.22 0-.34.1-.45s.22-.25.33-.38a1.41 1.41 0 0 0 .22-.36.41.41 0 0 0 0-.38c0-.11-.5-1.2-.69-1.65s-.36-.37-.5-.38h-.42a.82.82 0 0 0-.58.27 2.41 2.41 0 0 0-.78 1.81 4.28 4.28 0 0 0 .88 2.25 9.6 9.6 0 0 0 3.73 3.26 12.32 12.32 0 0 0 1.24.46 3 3 0 0 0 1.38.09 2.3 2.3 0 0 0 1.5-1.06 1.85 1.85 0 0 0 .13-1.06c-.05-.08-.19-.13-.41-.24Z" />
-              </svg>
-              <span className="text-xs text-muted-foreground">WhatsApp</span>
-            </a>
-          </div>
         </div>
       </div>
     </div>

--- a/packages/backend/convex/analytics.ts
+++ b/packages/backend/convex/analytics.ts
@@ -623,6 +623,140 @@ export const getUserDashboard = query({
   },
 });
 
+export const getWeeklyProgress = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return null;
+    }
+
+    const tokenIdentifier = identity.tokenIdentifier.split("|")[1] ?? identity.subject;
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", tokenIdentifier))
+      .unique();
+
+    if (!user) {
+      return null;
+    }
+
+    const now = Date.now();
+    const weekMs = 7 * 24 * 60 * 60 * 1000;
+    const currentStart = now - weekMs;
+    const previousStart = currentStart - weekMs;
+
+    const conversationsAsInitiator = await ctx.db
+      .query("conversations")
+      .withIndex("by_initiator", (q) => q.eq("initiatorUserId", user._id))
+      .filter((q) => q.neq(q.field("status"), "pending"))
+      .collect();
+
+    const conversationsAsScanner = await ctx.db
+      .query("conversations")
+      .withIndex("by_scanner", (q) => q.eq("scannerUserId", user._id))
+      .filter((q) => q.neq(q.field("status"), "pending"))
+      .collect();
+
+    const conversationMap = new Map(
+      [...conversationsAsInitiator, ...conversationsAsScanner].map((conversation) => [
+        conversation._id,
+        conversation,
+      ])
+    );
+
+    const allConversations = Array.from(conversationMap.values());
+    const getConversationTime = (conversation: typeof allConversations[number]) =>
+      conversation.endedAt ?? conversation.startedAt ?? conversation._creationTime;
+
+    const currentConversations = allConversations.filter((conversation) => {
+      const time = getConversationTime(conversation);
+      return time >= currentStart && time <= now;
+    });
+
+    const previousConversations = allConversations.filter((conversation) => {
+      const time = getConversationTime(conversation);
+      return time >= previousStart && time < currentStart;
+    });
+
+    const allAnalytics = await ctx.db
+      .query("speechAnalytics")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+
+    const analyticsWithTimes = await Promise.all(
+      allAnalytics.map(async (analytics) => {
+        const conversation =
+          conversationMap.get(analytics.conversationId) ??
+          (await ctx.db.get(analytics.conversationId));
+
+        return {
+          analytics,
+          time: conversation
+            ? conversation.endedAt ?? conversation.startedAt ?? conversation._creationTime
+            : analytics._creationTime,
+        };
+      })
+    );
+
+    const currentAnalytics = analyticsWithTimes
+      .filter(({ time }) => time >= currentStart && time <= now)
+      .map(({ analytics }) => analytics);
+
+    const previousAnalytics = analyticsWithTimes
+      .filter(({ time }) => time >= previousStart && time < currentStart)
+      .map(({ analytics }) => analytics);
+
+    const average = (values: number[]) =>
+      values.length > 0
+        ? values.reduce((sum, value) => sum + value, 0) / values.length
+        : null;
+
+    const percentageChange = (current: number | null, previous: number | null) => {
+      if (current === null || previous === null || previous === 0) return null;
+      return Math.round(((current - previous) / previous) * 100);
+    };
+
+    const currentConfidence = average(
+      currentAnalytics.map((analytics) => analytics.scores.confidence)
+    );
+    const previousConfidence = average(
+      previousAnalytics.map((analytics) => analytics.scores.confidence)
+    );
+
+    const currentFillerRate = average(
+      currentAnalytics.map((analytics) => analytics.fillerWords.ratePerMinute)
+    );
+    const previousFillerRate = average(
+      previousAnalytics.map((analytics) => analytics.fillerWords.ratePerMinute)
+    );
+
+    return {
+      conversations: {
+        current: currentConversations.length,
+        previous: previousConversations.length,
+        change: currentConversations.length - previousConversations.length,
+      },
+      confidence: {
+        current: currentConfidence === null ? null : Math.round(currentConfidence),
+        previous: previousConfidence === null ? null : Math.round(previousConfidence),
+        changePercent: percentageChange(currentConfidence, previousConfidence),
+      },
+      fillerWords: {
+        currentRate:
+          currentFillerRate === null ? null : Math.round(currentFillerRate * 10) / 10,
+        previousRate:
+          previousFillerRate === null ? null : Math.round(previousFillerRate * 10) / 10,
+        reductionPercent:
+          currentFillerRate === null || previousFillerRate === null || previousFillerRate === 0
+            ? null
+            : Math.round(((previousFillerRate - currentFillerRate) / previousFillerRate) * 100),
+      },
+    };
+  },
+});
+
 // Get personalized feedback for a conversation
 export const getPersonalizedFeedback = query({
   args: {

--- a/packages/backend/convex/chat.ts
+++ b/packages/backend/convex/chat.ts
@@ -1,10 +1,114 @@
 import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
 import { mutation, query } from "./_generated/server";
+
+const GENERAL_THREAD_KEY = "general";
+
+function buildThreadKey({
+  conversationId,
+  linkedConversationIds,
+  threadKey,
+}: {
+  conversationId?: Id<"conversations">;
+  linkedConversationIds?: Id<"conversations">[];
+  threadKey?: string;
+}) {
+  if (threadKey) {
+    return threadKey;
+  }
+
+  if (conversationId) {
+    return `conversation:${conversationId}`;
+  }
+
+  if (!linkedConversationIds || linkedConversationIds.length === 0) {
+    return GENERAL_THREAD_KEY;
+  }
+
+  const sortedIds = [...linkedConversationIds].map(String).sort();
+
+  if (sortedIds.length === 1) {
+    return `conversation:${sortedIds[0]}`;
+  }
+
+  return `multi:${sortedIds.join("|")}`;
+}
+
+function normalizeThreadKey(message: {
+  threadKey?: string;
+  conversationId?: Id<"conversations">;
+}) {
+  if (message.threadKey) {
+    return message.threadKey;
+  }
+
+  if (message.conversationId) {
+    return `conversation:${message.conversationId}`;
+  }
+
+  return GENERAL_THREAD_KEY;
+}
+
+function parseConversationIdsFromThreadKey(threadKey: string) {
+  if (threadKey === GENERAL_THREAD_KEY) {
+    return [];
+  }
+
+  if (threadKey.startsWith("conversation:")) {
+    return [threadKey.slice("conversation:".length)];
+  }
+
+  if (threadKey.startsWith("multi:")) {
+    return threadKey
+      .slice("multi:".length)
+      .split("|")
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function getSingleConversationId(threadKey: string) {
+  const ids = parseConversationIdsFromThreadKey(threadKey);
+  return ids.length === 1 ? (ids[0] as Id<"conversations">) : undefined;
+}
+
+function getThreadTitle(
+  threadKey: string,
+  conversationsById: Map<string, { location?: string; _creationTime: number }>
+) {
+  if (threadKey === GENERAL_THREAD_KEY) {
+    return "General chat";
+  }
+
+  const conversationIds = parseConversationIdsFromThreadKey(threadKey);
+
+  if (conversationIds.length === 1) {
+    const conversation = conversationsById.get(conversationIds[0]);
+    if (!conversation) {
+      return "Conversation chat";
+    }
+
+    if (conversation.location?.trim()) {
+      return conversation.location;
+    }
+
+    return new Date(conversation._creationTime).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  return `${conversationIds.length} linked conversations`;
+}
 
 // Get all chat messages for a conversation (for a specific user)
 export const getMessages = query({
   args: {
-    conversationId: v.id("conversations"),
+    conversationId: v.optional(v.id("conversations")),
+    linkedConversationIds: v.optional(v.array(v.id("conversations"))),
+    threadKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -22,23 +126,101 @@ export const getMessages = query({
       return [];
     }
 
-    // Get all messages for this conversation and user
-    const messages = await ctx.db
+    const threadKey = buildThreadKey({
+      conversationId: args.conversationId,
+      linkedConversationIds: args.linkedConversationIds,
+      threadKey: args.threadKey,
+    });
+
+    let messages = await ctx.db
       .query("chatMessages")
-      .withIndex("by_conversation_and_user", (q) =>
-        q.eq("conversationId", args.conversationId).eq("userId", user._id)
-      )
+      .withIndex("by_user_and_thread", (q) => q.eq("userId", user._id).eq("threadKey", threadKey))
       .collect();
+
+    const fallbackConversationId = args.conversationId ?? getSingleConversationId(threadKey);
+
+    if (messages.length === 0 && fallbackConversationId) {
+      messages = await ctx.db
+        .query("chatMessages")
+        .withIndex("by_conversation_and_user", (q) =>
+          q.eq("conversationId", fallbackConversationId).eq("userId", user._id)
+        )
+        .collect();
+    }
 
     // Sort by creation time
     return messages.sort((a, b) => a.createdAt - b.createdAt);
   },
 });
 
+export const listThreads = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return [];
+    }
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+
+    if (!user) {
+      return [];
+    }
+
+    const messages = await ctx.db
+      .query("chatMessages")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+
+    const latestByThread = new Map<string, (typeof messages)[number]>();
+
+    for (const message of messages) {
+      const threadKey = normalizeThreadKey(message);
+      const existing = latestByThread.get(threadKey);
+
+      if (!existing || message.createdAt > existing.createdAt) {
+        latestByThread.set(threadKey, message);
+      }
+    }
+
+    const conversationIds = Array.from(
+      new Set(
+        Array.from(latestByThread.keys()).flatMap((threadKey) => parseConversationIdsFromThreadKey(threadKey))
+      )
+    ) as Id<"conversations">[];
+
+    const conversations = await Promise.all(conversationIds.map((conversationId) => ctx.db.get(conversationId)));
+    const conversationsById = new Map(
+      conversations
+        .filter((conversation): conversation is NonNullable<typeof conversation> => Boolean(conversation))
+        .map((conversation) => [String(conversation._id), conversation])
+    );
+
+    return Array.from(latestByThread.entries())
+      .map(([threadKey, message]) => {
+        const linkedConversationIds = parseConversationIdsFromThreadKey(threadKey) as Id<"conversations">[];
+
+        return {
+          threadKey,
+          linkedConversationIds,
+          title: getThreadTitle(threadKey, conversationsById),
+          preview: message.content,
+          updatedAt: message.createdAt,
+        };
+      })
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  },
+});
+
 // Save a chat message
 export const saveMessage = mutation({
   args: {
-    conversationId: v.id("conversations"),
+    conversationId: v.optional(v.id("conversations")),
+    linkedConversationIds: v.optional(v.array(v.id("conversations"))),
+    threadKey: v.optional(v.string()),
     role: v.union(v.literal("user"), v.literal("assistant")),
     content: v.string(),
   },
@@ -58,16 +240,38 @@ export const saveMessage = mutation({
       throw new Error("User not found");
     }
 
-    // Verify conversation exists
-    const conversation = await ctx.db.get(args.conversationId);
-    if (!conversation) {
-      throw new Error("Conversation not found");
+    const singleConversationId =
+      args.conversationId ??
+      (args.linkedConversationIds?.length === 1 ? args.linkedConversationIds[0] : undefined);
+
+    if (singleConversationId) {
+      const conversation = await ctx.db.get(singleConversationId);
+      if (!conversation) {
+        throw new Error("Conversation not found");
+      }
     }
+
+    if (args.linkedConversationIds && args.linkedConversationIds.length > 1) {
+      const linkedConversations = await Promise.all(
+        args.linkedConversationIds.map((conversationId) => ctx.db.get(conversationId))
+      );
+
+      if (linkedConversations.some((conversation) => !conversation)) {
+        throw new Error("One or more linked conversations were not found");
+      }
+    }
+
+    const threadKey = buildThreadKey({
+      conversationId: singleConversationId,
+      linkedConversationIds: args.linkedConversationIds,
+      threadKey: args.threadKey,
+    });
 
     // Save the message
     const messageId = await ctx.db.insert("chatMessages", {
-      conversationId: args.conversationId,
+      conversationId: singleConversationId,
       userId: user._id,
+      threadKey,
       role: args.role,
       content: args.content,
       createdAt: Date.now(),

--- a/packages/backend/convex/conversations.ts
+++ b/packages/backend/convex/conversations.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { api } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
 import { action, internalMutation, mutation, query } from "./_generated/server";
 
 // Generate a random invite code
@@ -439,6 +440,14 @@ export const list = query({
       summary: v.optional(v.string()),
       audioStorageId: v.optional(v.id("_storage")),
       speakerMap: v.optional(v.any()),
+      participants: v.array(
+        v.object({
+          _id: v.id("users"),
+          name: v.optional(v.string()),
+          image: v.optional(v.string()),
+        })
+      ),
+      participantCount: v.number(),
     })
   ),
   handler: async (ctx) => {
@@ -467,12 +476,50 @@ export const list = query({
       .withIndex("by_scanner", (q) => q.eq("scannerUserId", user._id))
       .collect();
 
-    console.log("asInitiator", asInitiator);
-    console.log("asScanner", asScanner);
+    const userIds = new Set<string>();
+    for (const conversation of [...asInitiator, ...asScanner]) {
+      userIds.add(conversation.initiatorUserId);
+      if (conversation.scannerUserId) {
+        userIds.add(conversation.scannerUserId);
+      }
+    }
 
-    // Combine and sort by creation time
-    const all = [...asInitiator, ...asScanner];
-    return all.sort((a, b) => b._creationTime - a._creationTime);
+    const users = await Promise.all(
+      Array.from(userIds).map(async (userId) => {
+        const userDoc = await ctx.db.get(userId as Id<"users">);
+        return userDoc ? [userId, userDoc] : null;
+      })
+    );
+
+    const usersById = new Map(
+      users.filter((entry): entry is [string, Doc<"users">] => entry !== null)
+    );
+
+    const all = [...asInitiator, ...asScanner]
+      .sort((a, b) => b._creationTime - a._creationTime)
+      .map((conversation) => {
+        const participantIds = [conversation.initiatorUserId, conversation.scannerUserId].filter(
+          (id): id is Id<"users"> => Boolean(id)
+        );
+
+        const participants = participantIds
+          .map((userId) => usersById.get(userId))
+          .filter((participant): participant is Doc<"users"> => Boolean(participant))
+          .map((participant) => ({
+            _id: participant._id,
+            name: participant.name,
+            image: participant.image,
+          }));
+
+        return {
+          ...conversation,
+          participants,
+          participantCount:
+            new Set(participantIds).size + (conversation.anonymousSpeakerCount ?? 0),
+        };
+      });
+
+    return all;
   },
 });
 

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -61,8 +61,8 @@ export const chat = httpAction(async (ctx, req) => {
     return new Response("Origin not allowed", { status: 403 });
   }
 
-  // Extract the `messages` and optional `conversationId` from the body of the request
-  const { messages, conversationId } = await req.json();
+  // Extract the `messages` and optional conversation selectors from the body
+  const { messages, conversationId, conversationIds } = await req.json();
 
   // Get user identity from auth
   const identity = await ctx.auth.getUserIdentity();
@@ -170,13 +170,23 @@ export const chat = httpAction(async (ctx, req) => {
 
       } else {
         // === GENERAL MODE ===
-        // Load last 10 conversations (existing behavior)
+        // Load either linked conversations or the most recent history.
         const conversations = await ctx.runQuery(api.conversations.list, {});
+        const selectedConversationIds = Array.isArray(conversationIds)
+          ? new Set<string>(conversationIds)
+          : null;
+        const relevantConversations = selectedConversationIds?.size
+          ? conversations.filter((conversation) =>
+              selectedConversationIds.has(conversation._id)
+            )
+          : conversations;
 
-        if (conversations.length > 0) {
-          conversationContext = `\n\n## USER'S CONVERSATION HISTORY\nYou have access to ${conversations.length} conversation(s) from this user:\n\n`;
+        if (relevantConversations.length > 0) {
+          conversationContext = selectedConversationIds?.size
+            ? `\n\n## LINKED CONVERSATIONS\nThe user linked ${relevantConversations.length} conversation(s) for this coaching request:\n\n`
+            : `\n\n## USER'S CONVERSATION HISTORY\nYou have access to ${relevantConversations.length} conversation(s) from this user:\n\n`;
 
-          for (const conv of conversations.slice(0, 10)) {
+          for (const conv of relevantConversations.slice(0, 10)) {
             const transcript = await ctx.runQuery(api.conversations.getTranscript, {
               conversationId: conv._id
             });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -187,15 +187,17 @@ export default defineSchema({
 
   // AI Chatbot Messages (for persistent chat history per conversation)
   chatMessages: defineTable({
-    conversationId: v.id("conversations"),
+    conversationId: v.optional(v.id("conversations")),
     userId: v.id("users"),
+    threadKey: v.optional(v.string()),
     role: v.union(v.literal("user"), v.literal("assistant")),
     content: v.string(),
     createdAt: v.number(),
   })
     .index("by_conversation_and_user", ["conversationId", "userId"])
     .index("by_conversation", ["conversationId"])
-    .index("by_user", ["userId"]),
+    .index("by_user", ["userId"])
+    .index("by_user_and_thread", ["userId", "threadKey"]),
 
   // Background import jobs for long-running audio transcription.
   importJobs: defineTable({


### PR DESCRIPTION
Merge #45 before merging this one please.

This update makes the chat system use shared persisted chat threads instead of treating the dashboard chat page and the conversation-level chat as separate histories.

Backend-wise, the main change is in `chat.ts` and `schema.ts`. The existing `chatMessages` table is now used as a thread-backed store by introducing a thread key concept on top of the current per-message records. A chat thread is resolved deterministically from the selected conversation context:

- no linked conversations maps to a general chat thread
- one linked conversation maps to that single conversation’s chat thread
- multiple linked conversations map to a dedicated multi-conversation thread

That design is what prevents duplication. If a user starts a chat from an individual conversation page, that history is stored against that conversation’s thread and will also appear in the dashboard chat page history. Likewise, if the user links exactly one conversation inside the dashboard chat page, the app reuses that same underlying thread instead of creating a second copy of the conversation chat. If the user links two or more conversations, the resulting thread is chat-page-only and does not overwrite or replace the individual chat history for any of those conversations.