### PR TITLE
Consistent header styling for navbar pages, fix light components in darkmode for waiting view, settings page styling

### DIFF
--- a/apps/web/app/components/recording/WaitingView.tsx
+++ b/apps/web/app/components/recording/WaitingView.tsx
@@ -1,4 +1,4 @@
-import { Users, Loader2 } from "lucide-react";
+import { Loader2, Users } from "lucide-react";
 
 interface WaitingViewProps {
   conversationId: string;
@@ -8,46 +8,46 @@ export default function WaitingView({ conversationId }: WaitingViewProps) {
   return (
     <div className="w-full max-w-md space-y-6">
       {/* Main Waiting Section */}
-      <div className="bg-[#353E41] rounded-2xl p-8 flex flex-col items-center">
+      <div className="flex flex-col items-center rounded-2xl border border-border bg-card p-8 shadow-sm">
         <div className="relative mb-6">
-          <div className="w-24 h-24 rounded-full bg-blue-500/20 flex items-center justify-center">
-            <Loader2 className="w-12 h-12 text-blue-400 animate-spin" />
+          <div className="flex h-24 w-24 items-center justify-center rounded-full bg-primary/10">
+            <Loader2 className="h-12 w-12 animate-spin text-primary" />
           </div>
         </div>
 
-        <h2 className="text-xl font-medium mb-3">Transcription in Progress</h2>
-        <p className="text-sm text-gray-300 text-center max-w-xs">
+        <h2 className="mb-3 text-xl font-medium text-foreground">Transcription in Progress</h2>
+        <p className="max-w-xs text-center text-sm text-muted-foreground">
           The conversation is being recorded and transcribed on the other participant's device
         </p>
       </div>
 
       {/* Status Info */}
-      <div className="bg-[#353E41] rounded-2xl p-4 space-y-3">
+      <div className="space-y-3 rounded-2xl border border-border bg-card p-4 shadow-sm">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
-            <Users className="w-4 h-4 text-gray-400" />
-            <span className="text-sm text-gray-300">Status</span>
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">Status</span>
           </div>
-          <span className="text-sm text-blue-400">Active</span>
+          <span className="text-sm text-primary">Active</span>
         </div>
 
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
-            <div className="w-4 h-4 flex items-center justify-center">
-              <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+            <div className="flex h-4 w-4 items-center justify-center">
+              <div className="h-2 w-2 animate-pulse rounded-full bg-green-500" />
             </div>
-            <span className="text-sm text-gray-300">Recording</span>
+            <span className="text-sm text-muted-foreground">Recording</span>
           </div>
-          <span className="text-sm text-white">On other device</span>
+          <span className="text-sm text-foreground">On other device</span>
         </div>
       </div>
 
       {/* Instructions */}
       <div className="text-center space-y-2">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-muted-foreground">
           You'll receive the conversation insights and summary automatically once the recording is complete
         </p>
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-muted-foreground/70">
           Please wait while the other participant manages the recording
         </p>
       </div>

--- a/apps/web/app/routes/dashboard/analytics.tsx
+++ b/apps/web/app/routes/dashboard/analytics.tsx
@@ -3,16 +3,21 @@ import AnalyticsDashboard from "~/components/analytics/AnalyticsDashboard";
 
 export default function AnalyticsPage() {
   return (
-    <div className="h-full overflow-y-auto overflow-x-hidden custom-scrollbar">
-      <div className="@container/main flex min-h-full flex-col gap-2">
-        <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-          <div className="px-4 lg:px-6">
-            <div className="mb-6">
-              <h1 className="text-3xl font-bold text-white mb-2">Your Analytics</h1>
-              <p className="text-gray-400">
-                Track your communication performance and growth over time
-              </p>
-            </div>
+    <div className="flex h-[calc(100vh-4rem)] flex-col">
+      <div className="border-b border-border bg-sidebar backdrop-blur-sm dark:bg-card">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">Your Analytics</h1>
+            <p className="text-sm text-muted-foreground">
+              Track your communication performance and growth over time
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto overflow-x-hidden custom-scrollbar">
+        <div className="@container/main mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+          <div className="flex flex-col gap-4 md:gap-6">
             <AnalyticsDashboard />
           </div>
         </div>

--- a/apps/web/app/routes/dashboard/index.tsx
+++ b/apps/web/app/routes/dashboard/index.tsx
@@ -85,11 +85,11 @@ export default function Page() {
 
   return (
     <div className="flex flex-col h-[calc(100vh-4rem)]">
-      <div className="border-b border-border bg-sidebar dark:bg-card">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div className="border-b border-border bg-sidebar backdrop-blur-sm dark:bg-card">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h1 className="text-2xl font-bold text-foreground mb-1">
+              <h1 className="text-2xl font-bold text-foreground">
                 Welcome back, {firstName}
               </h1>
               <p className="text-sm text-muted-foreground">

--- a/apps/web/app/routes/dashboard/network.tsx
+++ b/apps/web/app/routes/dashboard/network.tsx
@@ -68,7 +68,7 @@ export default function NetworkPage() {
 
   return (
     <div className="flex h-[calc(100vh-4rem)] flex-col">
-      <div className="border-b border-border bg-card/50 backdrop-blur-sm">
+      <div className="border-b border-border bg-sidebar backdrop-blur-sm dark:bg-card">
         <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
           <div>
             <h1 className="text-2xl font-bold text-foreground">Network</h1>

--- a/apps/web/app/routes/dashboard/settings.tsx
+++ b/apps/web/app/routes/dashboard/settings.tsx
@@ -1,11 +1,10 @@
 "use client";
-import { useState } from "react";
 import { api } from "@audora/backend/convex/_generated/api";
 import { useQuery } from "convex/react";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
-import { Copy, Check } from "lucide-react";
 import SubscriptionStatus from "~/components/subscription-status";
-import ConnectionGraph from "~/components/network/ConnectionGraph";
 import { ThemeToggle } from "~/components/ThemeToggle";
 
 export default function Page() {
@@ -35,44 +34,58 @@ export default function Page() {
   };
 
   return (
-    <div className="h-full overflow-y-auto overflow-x-hidden custom-scrollbar">
-      <div className="@container/main flex min-h-full flex-col gap-2">
-        <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-          <div className="px-4 lg:px-6">
-            {/* Tab Navigation */}
-            <div className="flex gap-2 mb-6 border-b border-border">
-              <button
-                onClick={() => setActiveTab("profile")}
-                className={`px-4 py-2 font-medium transition-colors ${
-                  activeTab === "profile"
-                    ? "text-blue-500 border-b-2 border-blue-500"
-                    : "text-gray-400 hover:text-gray-300"
-                }`}
-              >
-                Profile
-              </button>
-              <button
-                onClick={() => setActiveTab("network")}
-                className={`px-4 py-2 font-medium transition-colors ${
-                  activeTab === "network"
-                    ? "text-blue-500 border-b-2 border-blue-500"
-                    : "text-gray-400 hover:text-gray-300"
-                }`}
-              >
-                Network
-              </button>
-              <button
-                onClick={() => setActiveTab("subscription")}
-                className={`px-4 py-2 font-medium transition-colors ${
-                  activeTab === "subscription"
-                    ? "text-blue-500 border-b-2 border-blue-500"
-                    : "text-gray-400 hover:text-gray-300"
-                }`}
-              >
-                Subscription
-              </button>
-            </div>
+    <div className="flex h-[calc(100vh-4rem)] flex-col">
+      <div className="border-b border-border bg-sidebar backdrop-blur-sm dark:bg-card">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">Settings</h1>
+            <p className="text-sm text-muted-foreground">
+              Manage your profile, network, and subscription preferences.
+            </p>
+          </div>
+        </div>
+      </div>
 
+      <div className="border-b border-border bg-sidebar backdrop-blur-sm dark:bg-card">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex gap-2">
+            <button
+              onClick={() => setActiveTab("profile")}
+              className={`border-0 border-b-2 border-transparent px-4 py-3 font-medium transition-colors ${
+                activeTab === "profile"
+                  ? "border-primary text-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Profile
+            </button>
+            <button
+              onClick={() => setActiveTab("network")}
+              className={`border-0 border-b-2 border-transparent px-4 py-3 font-medium transition-colors ${
+                activeTab === "network"
+                  ? "border-primary text-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Network
+            </button>
+            <button
+              onClick={() => setActiveTab("subscription")}
+              className={`border-0 border-b-2 border-transparent px-4 py-3 font-medium transition-colors ${
+                activeTab === "subscription"
+                  ? "border-primary text-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Subscription
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto overflow-x-hidden custom-scrollbar">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+          <div className="flex flex-col gap-4 md:gap-6">
             {/* Tab Content */}
             {activeTab === "profile" && (
               <div className="space-y-6">


### PR DESCRIPTION
Standardized the dashboard page headers so Analytics, Network, and the conversations list page all use the same top-bar structure, spacing, and fixed-header behavior while page content scrolls underneath. This makes navigation between pages feel consistent and removes the header shift that was happening before.

Also updated the invitee waiting/transcription-in-progress view to use the app’s shared light/dark theme tokens instead of hardcoded dark surfaces, so it now matches the rest of the app visually in light mode.

Finally, cleaned up the Settings page layout to match the other dashboard pages by fixing the page margins, updating the tab styling to use the app’s primary purple accent with a bottom-border-only active state, and keeping the settings tabs fixed while the page content scrolls.